### PR TITLE
Replace forkIO with forkOS in gloss main loop

### DIFF
--- a/essence-of-live-coding-gloss/src/LiveCoding/Gloss.hs
+++ b/essence-of-live-coding-gloss/src/LiveCoding/Gloss.hs
@@ -75,7 +75,7 @@ glossHandle GlossSettings { .. } = Handle
       glossPicRef <- newIORef blank
       glossExitRef <- newIORef False
       let glossVars = GlossVars { .. }
-      glossThread <- forkIO
+      glossThread <- forkOS
         $ playIO displaySetting backgroundColor stepsPerSecond glossVars getPicture (handleEvent debugEvents) stepGloss
       return GlossHandle { .. }
   , destroy = \GlossHandle { glossVars = GlossVars { .. }, .. } -> writeIORef glossExitRef True


### PR DESCRIPTION
Hopefully fixes gloss errors on macOS.
See https://github.com/turion/essence-of-live-coding-tutorial/issues/3