### PR TITLE
Dev parametrised handle

### DIFF
--- a/essence-of-live-coding/essence-of-live-coding.cabal
+++ b/essence-of-live-coding/essence-of-live-coding.cabal
@@ -56,6 +56,7 @@ library
     , LiveCoding.GHCi
     , LiveCoding.Handle
     , LiveCoding.Handle.Examples
+    , LiveCoding.HandlingState
     , LiveCoding.LiveProgram
     , LiveCoding.LiveProgram.Except
     , LiveCoding.LiveProgram.HotCodeSwap

--- a/essence-of-live-coding/src/LiveCoding.hs
+++ b/essence-of-live-coding/src/LiveCoding.hs
@@ -24,6 +24,15 @@ import LiveCoding.Exceptions as X
 import LiveCoding.Exceptions.Finite as X
 import LiveCoding.Forever as X
 import LiveCoding.Handle as X
+import LiveCoding.HandlingState as X
+    ( HandlingStateT,
+      HandlingState(..),
+      Handling(..),
+      isRegistered,
+      runHandlingStateT,
+      runHandlingStateC,
+      runHandlingState,
+    )
 import LiveCoding.Handle.Examples as X
 import LiveCoding.LiveProgram as X
 import LiveCoding.LiveProgram.HotCodeSwap as X

--- a/essence-of-live-coding/src/LiveCoding/Cell/NonBlocking.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/NonBlocking.hs
@@ -15,6 +15,7 @@ import Data.Data
 import LiveCoding.Cell
 import LiveCoding.Handle
 import LiveCoding.Handle.Examples
+import LiveCoding.HandlingState
 
 threadVarHandle :: Handle IO (MVar ThreadId)
 threadVarHandle = Handle

--- a/essence-of-live-coding/src/LiveCoding/Handle.hs
+++ b/essence-of-live-coding/src/LiveCoding/Handle.hs
@@ -163,9 +163,6 @@ This means that handles are only migrated if they have exactly the same type.
 handling
   :: ( Typeable h
      , Monad m
-    --  , MonadBase m m
-    --  , MonadState (HandlingState m) n
-    --  , MonadBase m n
      )
   => Handle m h
   -> Cell (HandlingStateT m) arbitrary h

--- a/essence-of-live-coding/src/LiveCoding/Handle.hs
+++ b/essence-of-live-coding/src/LiveCoding/Handle.hs
@@ -73,7 +73,7 @@ handling handleImpl@Handle { .. } = Cell
   { cellState = Uninitialized
   , cellStep = \state input -> case state of
       handling@Handling { .. } -> do
-        reregister (destroy handle) handling
+        reregister (destroy handle) key handle
         return (handle, state)
       Uninitialized -> do
         handle <- lift create

--- a/essence-of-live-coding/src/LiveCoding/HandlingState.hs
+++ b/essence-of-live-coding/src/LiveCoding/HandlingState.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module LiveCoding.HandlingState where
+
+-- base
+import Control.Arrow (returnA, arr, (>>>))
+import Data.Data
+
+-- transformers
+import Control.Monad.Trans.Class (MonadTrans(lift))
+import Control.Monad.Trans.State.Strict
+import Data.Foldable (traverse_)
+
+-- containers
+import Data.IntMap
+import qualified Data.IntMap as IntMap
+
+-- essence-of-live-coding
+import LiveCoding.Cell
+import LiveCoding.Cell.Monad
+import LiveCoding.Cell.Monad.Trans
+import LiveCoding.LiveProgram
+import LiveCoding.LiveProgram.Monad.Trans
+
+data Handling h where
+  Handling
+    :: { key    :: Key
+       , handle :: h
+       }
+    -> Handling h
+  Uninitialized :: Handling h
+
+type Destructors m = IntMap (Destructor m)
+
+-- | Hold a map of registered handle keys and destructors
+data HandlingState m = HandlingState
+  { nHandles    :: Key
+  , destructors :: Destructors m
+  }
+  deriving Data
+
+-- | In this monad, handles can be registered,
+--   and their destructors automatically executed.
+--   It is basically a monad in which handles are automatically garbage collected.
+type HandlingStateT m = StateT (HandlingState m) m
+
+initHandlingState :: HandlingState m
+initHandlingState = HandlingState
+  { nHandles = 0
+  , destructors = IntMap.empty
+  }
+
+-- | Handle the 'HandlingStateT' effect _without_ garbage collection.
+--   Apply this to your main loop after calling 'foreground'.
+--   Since there is no garbage collection, don't use this function for live coding.
+runHandlingStateT
+  :: Monad m
+  => HandlingStateT m a
+  -> m a
+runHandlingStateT = flip evalStateT initHandlingState
+
+{- | Apply this to your main live cell before passing it to the runtime.
+
+On the first tick, it initialises the 'HandlingState' at "no handles".
+
+On every step, it does:
+
+1. Unregister all handles
+2. Register currently present handles
+3. Destroy all still unregistered handles
+   (i.e. those that were removed in the last tick)
+-}
+runHandlingStateC
+  :: forall m a b .
+     (Monad m, Typeable m)
+  => Cell (HandlingStateT m) a b
+  -> Cell                 m  a b
+runHandlingStateC cell = flip runStateC_ initHandlingState
+  $ hoistCellOutput garbageCollected cell
+
+-- | Like 'runHandlingStateC', but for whole live programs.
+runHandlingState
+  :: (Monad m, Typeable m)
+  => LiveProgram (HandlingStateT m)
+  -> LiveProgram                 m
+runHandlingState LiveProgram { .. } = flip runStateL initHandlingState LiveProgram
+  { liveStep = garbageCollected . liveStep
+  , ..
+  }
+
+garbageCollected
+  :: Monad m
+  => HandlingStateT m a
+  -> HandlingStateT m a
+garbageCollected action = unregisterAll >> action <* destroyUnregistered
+
+data Destructor m = Destructor
+  { isRegistered :: Bool
+  , action       :: m ()
+  }
+
+
+register
+  :: Monad m
+  => m () -- ^ Destructor
+  -> h -- ^ Handle value
+  -> HandlingStateT m Key
+register destructor handle = do
+  HandlingState { .. } <- get
+  let key = nHandles + 1
+  put HandlingState
+    { nHandles = key
+    , destructors = insertDestructor destructor key handle destructors
+    }
+  return key
+
+reregister
+  :: Monad m
+  => m ()
+  -> Handling h -- FIXME Unsafe since this might be Uninitialized
+  -> HandlingStateT m ()
+reregister action Handling { .. } = do
+  HandlingState { .. } <- get
+  put HandlingState { destructors = insertDestructor action key handle destructors, .. }
+
+insertDestructor
+  :: m ()
+  -> Key
+  -> h
+  -> Destructors m
+  -> Destructors m
+insertDestructor action key handle destructors =
+  let destructor = Destructor { isRegistered = True, .. }
+  in  insert key destructor destructors
+
+unregisterAll
+  :: Monad m
+  => HandlingStateT m ()
+unregisterAll = do
+  HandlingState { .. } <- get
+  let newDestructors = IntMap.map (\destructor -> destructor { isRegistered = False }) destructors
+  put HandlingState { destructors = newDestructors, .. }
+
+destroyUnregistered
+  :: Monad m
+  => HandlingStateT m ()
+destroyUnregistered = do
+  HandlingState { .. } <- get
+  let
+      (registered, unregistered) = partition isRegistered destructors
+  traverse_ (lift . action) unregistered
+  put HandlingState { destructors = registered, .. }
+
+-- * 'Data' instances
+
+dataTypeHandling :: DataType
+dataTypeHandling = mkDataType "Handling" [handlingConstr, uninitializedConstr]
+
+handlingConstr :: Constr
+handlingConstr = mkConstr dataTypeHandling "Handling" [] Prefix
+
+uninitializedConstr :: Constr
+uninitializedConstr = mkConstr dataTypeHandling "Uninitialized" [] Prefix
+
+instance (Typeable h) => Data (Handling h) where
+  dataTypeOf _ = dataTypeHandling
+  toConstr Handling { .. } = handlingConstr
+  toConstr Uninitialized = uninitializedConstr
+  gunfold _cons nil constructor = nil Uninitialized
+
+dataTypeDestructor :: DataType
+dataTypeDestructor = mkDataType "Destructor" [ destructorConstr ]
+
+destructorConstr :: Constr
+destructorConstr = mkConstr dataTypeDestructor "Destructor" [] Prefix
+
+instance Typeable m => Data (Destructor m) where
+  dataTypeOf _ = dataTypeDestructor
+  toConstr Destructor { .. } = destructorConstr
+  gunfold _ _ = error "Destructor.gunfold"

--- a/essence-of-live-coding/src/LiveCoding/HandlingState.hs
+++ b/essence-of-live-coding/src/LiveCoding/HandlingState.hs
@@ -120,9 +120,10 @@ register destructor handle = do
 reregister
   :: Monad m
   => m ()
-  -> Handling h -- FIXME Unsafe since this might be Uninitialized
+  -> Key
+  -> h
   -> HandlingStateT m ()
-reregister action Handling { .. } = do
+reregister action key handle = do
   HandlingState { .. } <- get
   put HandlingState { destructors = insertDestructor action key handle destructors, .. }
 

--- a/essence-of-live-coding/src/LiveCoding/RuntimeIO/Launch.hs
+++ b/essence-of-live-coding/src/LiveCoding/RuntimeIO/Launch.hs
@@ -22,6 +22,7 @@ import LiveCoding.LiveProgram.Except
 import LiveCoding.LiveProgram.HotCodeSwap
 import LiveCoding.Cell.Monad.Trans
 import LiveCoding.Exceptions.Finite (Finite)
+import LiveCoding.HandlingState
 
 {- | Monads in which live programs can be launched in 'IO',
 for example when you have special effects that have to be handled on every reload.

--- a/essence-of-live-coding/test/Handle.hs
+++ b/essence-of-live-coding/test/Handle.hs
@@ -15,14 +15,8 @@ import Control.Monad.Trans.State.Strict
 -- test-framework
 import Test.Framework
 
--- test-framework
-import Test.Framework
-
 -- test-framework-quickcheck2
 import Test.Framework.Providers.QuickCheck2
-
--- QuickCheck
-import Test.QuickCheck
 
 -- essence-of-live-coding
 import qualified Handle.LiveProgram
@@ -44,7 +38,7 @@ testUnitHandle = Handle
   }
 
 cellWithAction
-  :: forall a b . (State Int b)
+  :: forall a b . State Int b
   -> Cell Identity a (String, Int)
 cellWithAction action = flip runStateC 0 $ runHandlingStateC $ handling testHandle >>> arrM (<$ lift action)
 

--- a/essence-of-live-coding/test/Handle/LiveProgram.hs
+++ b/essence-of-live-coding/test/Handle/LiveProgram.hs
@@ -49,5 +49,5 @@ test = testGroup "Handle.LiveProgram"
         HandlingState { .. } <- get
         lift $ tell
           [ "Handles: " ++ show nHandles
-          , "Destructors: " ++ unwords ((show . second isRegistered) <$> IntMap.toList destructors)
+          , "Destructors: " ++ unwords (show . second isRegistered <$> IntMap.toList destructors)
           ]


### PR DESCRIPTION
Handles should be generalised so we can put parameters in the code that cause reinitialisation when changed. It's often possible to put such information on the type level, but quickly gets tedious.

* [x] Merge #48 first or rebase to get rid of some extraneous commits.
* [x] Clean up git history
* [x] Add tests
* [x] Do I want to make `Handle` an alias on top of `ParametrisedHandle`?