### PR TITLE
add stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,26 @@ addons:
 cache:
   directories:
     - $HOME/.cabal
-ghc:
-  - '8.10'
-  - '8.8'
-  - '8.6'
+    - $HOME/.stack
+    - $TRAVIS_BUILD_DIR/.stack-work
+
+matrix:
+  include:
+
+  # Cabal
+  - ghc: '8.10'
+  - ghc: '8.8'
+  - ghc: '8.6'
+
+  # Stack
+  - ghc: '8.10.4'
+    env: STACK_YAML="stack.yaml"
+  - ghc: '8.8.4'
+    env: STACK_YAML="stack-lts-16.31.yaml"
+  - ghc: '8.6.5'
+    env: STACK_YAML="stack-lts-14.27.yaml"
+
 script:
-  - cabal new-build all --enable-tests
-  - cabal new-test all --enable-tests
-  - git fetch origin master:origin/master && git rebase origin/master --exec "cabal new-build all --enable-tests"
+  - bash travis-build.sh    
+
 install: skip

--- a/essence-of-live-coding-speedtest-yampa/app/SpeedTest.hs
+++ b/essence-of-live-coding-speedtest-yampa/app/SpeedTest.hs
@@ -3,6 +3,8 @@
 
 {-# LANGUAGE Arrows #-}
 
+module Main (main) where
+  
 -- base
 import Control.Arrow
 import Control.Monad (void)

--- a/essence-of-live-coding-speedtest-yampa/app/SpeedTestYampa.hs
+++ b/essence-of-live-coding-speedtest-yampa/app/SpeedTestYampa.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE Arrows #-}
 
+module Main (main) where
+
 -- base
 import Data.Maybe (isJust)
 

--- a/stack-lts-14.27.yaml
+++ b/stack-lts-14.27.yaml
@@ -1,0 +1,26 @@
+resolver: lts-14.27
+
+packages:
+- essence-of-live-coding
+- essence-of-live-coding-gloss
+- essence-of-live-coding-gloss-example
+- essence-of-live-coding-pulse
+- essence-of-live-coding-pulse-example
+- essence-of-live-coding-quickcheck
+- essence-of-live-coding-speedtest-yampa
+- essence-of-live-coding-warp
+- demos
+- gears
+
+extra-deps:
+- Yampa-0.13.1@sha256:4612a2646c27bcd3ac55c90dbc34249303e28aa5b3bc3e0c6fa9ce58b889843c,5436
+- pulse-simple-0.1.14@sha256:cd2397c40feb8959cdc6e806987072ce91e388e41427c47ff09ec2a2cfb466f0,773
+- simple-affine-space-0.1.1@sha256:c2afdf618a641cebe213820ed3df82da62aee325483ea848a267d1d39b41f868,1933
+- warp-3.3.16@sha256:19d9c611d22f2ee6cdea5b2ff123590f58cf717211505a792b96ddb1e0456b65,10910
+- directory-1.3.6.2@sha256:6e5f3e0adfe94483d5754d97d741b7d23a5e085d47176075b1955d4fa78f37aa,2811
+- process-1.6.11.0@sha256:d69428130705782d1b61ec8eab2f1d899fd5722ed804c44e104d798dce43e9fb,2819
+- time-1.9.3@sha256:8f1b5448722a12a952248b356c9eb366e351226543d9086a2da71270522d5f45,5679
+- unix-2.7.2.2@sha256:ddb8fc5d5eede81dfad7846eceb65267fe4cf8b4f324bc74542f694a32335ef2,3496
+- http2-3.0.2@sha256:7ef3389c98243da89960dc5b874d20d56c335f4319ee040cda7eea2d4ded308f,15814
+- network-byte-order-0.1.6@sha256:23d8b609ac43a69d04d5e8f411e5f86a0266c0e8b33b65f8c92ebda64273fe3a,1313
+- http-client-0.7.8@sha256:ed76dcd7edec3aaebe012541ca0a52594405e9b21d69420d26c0223bc4d5dc82,5400

--- a/stack-lts-16.31.yaml
+++ b/stack-lts-16.31.yaml
@@ -1,0 +1,17 @@
+resolver: lts-16.23
+
+packages:
+- essence-of-live-coding
+- essence-of-live-coding-gloss
+- essence-of-live-coding-gloss-example
+- essence-of-live-coding-pulse
+- essence-of-live-coding-pulse-example
+- essence-of-live-coding-quickcheck
+- essence-of-live-coding-speedtest-yampa
+- essence-of-live-coding-warp
+- demos
+- gears
+
+extra-deps:
+- Yampa-0.13.1@sha256:4612a2646c27bcd3ac55c90dbc34249303e28aa5b3bc3e0c6fa9ce58b889843c,5436
+- http-client-0.7.8@sha256:ed76dcd7edec3aaebe012541ca0a52594405e9b21d69420d26c0223bc4d5dc82,5400

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,17 @@
+resolver: lts-17.15
+
+packages:
+- essence-of-live-coding
+- essence-of-live-coding-gloss
+- essence-of-live-coding-gloss-example
+- essence-of-live-coding-pulse
+- essence-of-live-coding-pulse-example
+- essence-of-live-coding-quickcheck
+- essence-of-live-coding-speedtest-yampa
+- essence-of-live-coding-warp
+- demos
+- gears
+
+extra-deps:
+- Yampa-0.13.1@sha256:4612a2646c27bcd3ac55c90dbc34249303e28aa5b3bc3e0c6fa9ce58b889843c,5436
+- http-client-0.7.8@sha256:ed76dcd7edec3aaebe012541ca0a52594405e9b21d69420d26c0223bc4d5dc82,5400

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "$STACK_YAML" ]; then
+    cabal new-build all --enable-tests
+    cabal new-test all --enable-tests
+    # git fetch origin master:origin/master && git rebase origin/master --exec "cabal new-build all --enable-tests"
+else
+    # install stack
+    curl -sSL https://get.haskellstack.org/ | sh
+
+    # build project with stack
+    stack --version
+    stack build --system-ghc --test
+    # git fetch origin master:origin/master && git rebase origin/master --exec "stack build --system-ghc --test"
+fi


### PR DESCRIPTION
This adds support for building all packages with a single stack yaml file.  CI is implemented for 3 versions of ghc and it is building correctly in travis. I've added stack to the travis cache to speed-up builds. 

For some reason the executables in essence-of-live-coding-speedtest-yampa/app only build with stack if they have a module. I've added a module which allows building with stack, or an alternative can be not to change the files and also not build that package with stack.

Some questions:

- Do you want to keep 3 ghc versions also for stack ?
- Do you want to run the tests also on stack builds (currently they do) ?
- Rebasing on master is currently failing (before this pull-request), so I left that commented. Once the rebase doesn't fail it can be uncommented.