### PR TITLE
liveSynth - avoid having to explicitly create synthdef

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
       - libpulse-dev
       - libblas-dev
       - liblapack-dev
+      - libasound2-dev
     sources:
       - sourceline: 'ppa:hvr/ghc'
 cache:

--- a/README.md
+++ b/README.md
@@ -211,3 +211,8 @@ it's advisable to follow these patterns:
   (at least version 3).
   If this is not the case for you,
   consider updating, or adapt the files to use `new-`style commands.
+
+## Contributors
+
+* Manuel Bärenz https://github.com/turion/
+* Miguel Negrão https://github.com/miguel-negrao/

--- a/essence-of-live-coding-PortMidi/CHANGELOG.md
+++ b/essence-of-live-coding-PortMidi/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Revision history for essence-of-live-coding-vivid
+# Revision history for essence-of-live-coding-PortMidi
 
 ## 0.2.5
 

--- a/essence-of-live-coding-PortMidi/LICENSE
+++ b/essence-of-live-coding-PortMidi/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2021, Manuel Bärenz
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Manuel Bärenz nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/essence-of-live-coding-PortMidi/essence-of-live-coding-PortMidi.cabal
+++ b/essence-of-live-coding-PortMidi/essence-of-live-coding-PortMidi.cabal
@@ -1,0 +1,35 @@
+name:                essence-of-live-coding-PortMidi
+version:             0.2.5
+synopsis: General purpose live coding framework - PortMidi backend
+description:
+  essence-of-live-coding is a general purpose and type safe live coding framework.
+  .
+  You can run programs in it, and edit, recompile and reload them while they're running.
+  Internally, the state of the live program is automatically migrated when performing hot code swap.
+  .
+  The library also offers an easy to use FRP interface.
+  It is parametrized by its side effects,
+  separates data flow cleanly from control flow,
+  and allows to develop live programs from reusable, modular components.
+  There are also useful utilities for debugging and quickchecking.
+  .
+  This package contains the backend for PortMidi, a portable MIDI library.
+license:             BSD3
+license-file:        LICENSE
+author:              Manuel Bärenz
+maintainer:          programming@manuelbaerenz.de
+copyright:           2021 Manuel Bärenz
+category:            Sound
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:
+      LiveCoding.PortMidi
+  build-depends:
+      base >= 4.7
+    , transformers >= 0.5
+    , PortMidi >= 0.2
+    , essence-of-live-coding >= 0.2.5
+  hs-source-dirs:   src
+  default-language: Haskell2010

--- a/essence-of-live-coding-PortMidi/essence-of-live-coding-PortMidi.cabal
+++ b/essence-of-live-coding-PortMidi/essence-of-live-coding-PortMidi.cabal
@@ -30,6 +30,7 @@ library
       base >= 4.7
     , transformers >= 0.5
     , PortMidi >= 0.2
+    , mmorph >= 1.1
     , essence-of-live-coding >= 0.2.5
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
+++ b/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
@@ -102,3 +102,26 @@ portMidiInputWithProxy proxy = Handle
 
 handlingPortMidiInput :: (KnownSymbol name, MonadIO m) => Cell (HandlingStateT m) PortMidiHandle (Maybe (PortMidiInputStream (name :: Symbol)))
 handlingPortMidiInput = handling $ portMidiInputWithProxy Proxy
+
+data PortMidiDevices = PortMidiDevices
+  { inputDevices :: [DeviceInfo]
+  , outputDevices :: [DeviceInfo]
+  }
+
+getPortMidiDevices :: IO PortMidiDevices
+getPortMidiDevices = do
+  nDevices <- countDevices
+  devices <- mapM getDeviceInfo [0..nDevices-1]
+  return PortMidiDevices
+    { inputDevices = filter input devices
+    , outputDevices = filter output devices
+    }
+
+prettyPrintPortMidiDevices :: PortMidiDevices -> IO ()
+prettyPrintPortMidiDevices PortMidiDevices { .. } = do
+  putStrLn "\nPortMidi input devices:"
+  putStrLn $ unlines $ printName <$> inputDevices
+  putStrLn "\nPortMidi output devices:"
+  putStrLn $ unlines $ printName <$> outputDevices
+  where
+    printName dev = "- \"" ++ name dev ++ "\""

--- a/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
+++ b/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Arrows #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -15,6 +16,8 @@ module LiveCoding.PortMidi where
 import Control.Monad (void, forM, join)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Either (fromRight)
+import Data.Foldable (traverse_)
+import Data.Function ((&))
 import Data.Maybe (catMaybes)
 import GHC.Generics
 import GHC.TypeLits (Symbol, symbolVal, KnownSymbol)
@@ -27,40 +30,51 @@ import Sound.PortMidi
 
 -- essence-of-live-coding
 import LiveCoding
-import LiveCoding.LiveProgram.Except (foreverCLiveProgram)
-import qualified LiveCoding.LiveProgram.Except as LiveProgram
+
+data EOLCPortMidiError
+  = PMError PMError
+  | NoSuchDevice
+  | NotAnInputDevice
+  | NotAnOutputDevice
+  deriving (Data, Generic, Show)
+
+instance Finite EOLCPortMidiError
 
 -- | The monad transformer of PortMidi exceptions
-newtype PortMidiT m a = PortMidiT { unPortMidi :: ExceptT PMError m a }
-  deriving (Functor, Applicative, Monad)
+newtype PortMidiT m a = PortMidiT { unPortMidi :: ExceptT EOLCPortMidiError m a }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+throwPortMidi :: Monad m => EOLCPortMidiError -> PortMidiT m arbitrary
+throwPortMidi = PortMidiT . throwE
+
+throwPortMidiC :: Monad m => Cell (PortMidiT m) EOLCPortMidiError arbitrary
+throwPortMidiC = arrM throwPortMidi
 
 instance MonadTrans PortMidiT where
   lift = PortMidiT . lift
 
--- | Initialize the MIDI system, run the action, and shut it down again.
-runPortMidiT :: MonadIO m => PortMidiT m a -> ExceptT PMError m a
-runPortMidiT PortMidiT { .. } = ExceptT $ do
-  liftIO initialize
-  a <- runExceptT unPortMidi
-  liftIO $ void terminate
-  return a
+liftPMError :: Functor m => m (Either PMError a) -> PortMidiT m a
+liftPMError = PortMidiT . ExceptT . fmap (left PMError)
 
-instance (Launchable m, MonadIO m) => Launchable (PortMidiT m) where
-  runIO liveProgram = runIO $ foreverCLiveProgram $ do
-    e <- LiveProgram.try $ hoistLiveProgram unPortMidi liveProgram
-    once $ liftIO $ do
-      putStrLn "Encountered PortMidi exception:"
-      print e
-    return e
-    where
-      -- Will be part of essence-of-live-coding-0.2.6
-      once :: (Monad m, Data e, Finite e) => m e -> LiveProgram.LiveProgramExcept m e
-      once action = LiveProgram.try $ liveCell $ constM $ ExceptT $ Left <$> action
+-- | Initialize the MIDI system, run the action, and shut it down again.
+runPortMidiC :: MonadIO m => Cell (PortMidiT m) a b -> CellExcept (HandlingStateT m) a b EOLCPortMidiError
+runPortMidiC cell = try $ proc a -> do
+  _ <- liftCell $ handling portMidiHandle -< ()
+  hoistCell (mapExceptT lift . unPortMidi) cell -< a
+
+loopPortMidiC :: MonadIO m => Cell (PortMidiT m) a b -> Cell (HandlingStateT m) a b
+loopPortMidiC cell = foreverC $ runCellExcept $ do
+  e <- runPortMidiC cell
+  once_ $ liftIO $ do
+    putStrLn "Encountered PortMidi exception:"
+    print e
+  return e
 
 deriving instance Data PMError
 deriving instance Generic PMError
 instance Finite PMError
 
+-- FIXME do we still need this?
 -- | A marker to make sure that PortMidi was initialized
 data PortMidiHandle = PortMidiHandle
 
@@ -72,36 +86,69 @@ portMidiHandle = Handle
   , destroy = const $ liftIO $ void terminate
   }
 
-newtype PortMidiInputStream (name :: Symbol) = PortMidiInputStream { unPortMidiInputStream :: PMStream }
+newtype PortMidiInputStream = PortMidiInputStream { unPortMidiInputStream :: PMStream }
+newtype PortMidiOutputStream = PortMidiOutputStream { unPortMidiOutputStream :: PMStream }
 
-portMidiInputStreamAtProxyName :: Proxy name -> PMStream -> PortMidiInputStream name
-portMidiInputStreamAtProxyName _ = PortMidiInputStream
+lookupDeviceID :: MonadIO m => String -> (DeviceInfo -> Maybe EOLCPortMidiError) -> PortMidiT m DeviceID
+lookupDeviceID nameLookingFor filter = do
+  nDevices <- liftIO countDevices
+  devices <- forM [0..nDevices-1] $ \deviceID -> do
+    deviceInfo <- liftIO $ getDeviceInfo deviceID
+    traverse_ throwPortMidi $ filter deviceInfo
+    return (name deviceInfo, deviceID)
+  maybe (throwPortMidi NoSuchDevice) return $ lookup nameLookingFor devices
 
-portMidiInput
-  :: (MonadIO m, KnownSymbol name)
-  => PortMidiHandle
-  -> Handle m (Maybe (PortMidiInputStream (name :: Symbol)))
-portMidiInput _ = portMidiInputWithProxy Proxy
-
-portMidiInputWithProxy
-  :: (MonadIO m, KnownSymbol name)
-  => Proxy (name :: Symbol)
-  -> Handle m (Maybe (PortMidiInputStream (name :: Symbol)))
-portMidiInputWithProxy proxy = Handle
-  { create = liftIO $ do
-      nDevices <- countDevices
-      devices <- forM [0..nDevices-1] $ \deviceID -> do
-        deviceInfo <- getDeviceInfo deviceID
-        return $ if input deviceInfo then Just (name deviceInfo, deviceID) else Nothing
-      let deviceID = lookup (symbolVal proxy) $ catMaybes devices
-      pmStreamE <- mapM openInput deviceID
-      let pmStream = either (const Nothing) Just =<< pmStreamE
-      return $ portMidiInputStreamAtProxyName proxy <$> pmStream
-  , destroy = maybe (return ()) $ liftIO . void . close . unPortMidiInputStream
+portMidiInputStreamHandle
+  :: MonadIO m
+  => String
+  -> Handle (PortMidiT m) PortMidiInputStream
+portMidiInputStreamHandle name = Handle
+  { create = do
+      deviceID <- lookupDeviceID name $ \DeviceInfo { .. } -> if input then Nothing else Just NotAnInputDevice
+      PortMidiInputStream <$> liftPMError (liftIO (openInput deviceID))
+  , destroy = liftIO . void . close . unPortMidiInputStream
   }
 
-handlingPortMidiInput :: (KnownSymbol name, MonadIO m) => Cell (HandlingStateT m) PortMidiHandle (Maybe (PortMidiInputStream (name :: Symbol)))
-handlingPortMidiInput = handling $ portMidiInputWithProxy Proxy
+readEventsFrom
+  :: MonadIO m
+  => Cell (PortMidiT m) PortMidiInputStream [PMEvent]
+readEventsFrom = arrM $ liftPMError . liftIO . readEvents . unPortMidiInputStream
+
+readEventsC
+  :: MonadIO m
+  => String -> Cell (HandlingStateT (PortMidiT m)) arbitrary [PMEvent]
+readEventsC name = proc _ -> do
+  pmstream <- handling $ portMidiInputStreamHandle name -< ()
+  liftCell readEventsFrom -< pmstream
+
+portMidiOutputStreamHandle
+  :: MonadIO m
+  => String
+  -> Handle (PortMidiT m) PortMidiOutputStream
+portMidiOutputStreamHandle name = Handle
+  { create = do
+      deviceID <- lookupDeviceID name $ \DeviceInfo { .. } -> if output then Nothing else Just NotAnOutputDevice
+      -- Choose same latency as supercollider, see https://github.com/supercollider/supercollider/blob/18c4aad363c49f29e866f884f5ac5bd35969d828/lang/LangPrimSource/SC_PortMIDI.cpp#L416
+      -- Thanks Miguel Negrão
+      PortMidiOutputStream <$> liftPMError (liftIO (openOutput deviceID 0))
+  , destroy = liftIO . void . close . unPortMidiOutputStream
+  }
+
+writeEventsTo
+  :: MonadIO m
+  => Cell (PortMidiT m) (PortMidiOutputStream, [PMEvent]) ()
+writeEventsTo = arrM writer
+  where
+    writer (PortMidiOutputStream { .. }, events) = writeEvents unPortMidiOutputStream events
+      & liftIO
+      & liftPMError
+      & void
+
+writeEventsC
+  :: String -> Cell (HandlingStateT (PortMidiT IO)) [PMEvent] ()
+writeEventsC name = proc events -> do
+  portMidiOutputStream <- handling (portMidiOutputStreamHandle name) -< ()
+  liftCell writeEventsTo -< (portMidiOutputStream, events)
 
 data PortMidiDevices = PortMidiDevices
   { inputDevices :: [DeviceInfo]

--- a/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
+++ b/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
@@ -13,6 +13,7 @@
 module LiveCoding.PortMidi where
 
 -- base
+import Control.Concurrent (threadDelay)
 import Control.Monad (void, forM, join)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Either (fromRight)
@@ -68,6 +69,7 @@ loopPortMidiC cell = foreverC $ runCellExcept $ do
   once_ $ liftIO $ do
     putStrLn "Encountered PortMidi exception:"
     print e
+    threadDelay 1000
   return e
 
 deriving instance Data PMError

--- a/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
+++ b/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+module LiveCoding.PortMidi where
+
+-- base
+import Control.Monad (void, forM, join)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Either (fromRight)
+import GHC.Generics
+import GHC.TypeLits (Symbol, symbolVal, KnownSymbol)
+
+-- transformers
+import Control.Monad.Trans.Class
+
+-- PortMidi
+import Sound.PortMidi
+
+-- essence-of-live-coding
+import LiveCoding
+import LiveCoding.LiveProgram.Except (foreverCLiveProgram)
+import qualified LiveCoding.LiveProgram.Except as LiveProgram
+
+-- | The monad transformer of PortMidi exceptions
+newtype PortMidiT m a = PortMidiT { unPortMidi :: ExceptT PMError m a }
+  deriving (Functor, Applicative, Monad)
+
+instance MonadTrans PortMidiT where
+  lift = PortMidiT . lift
+
+-- | Initialize the MIDI system, run the action, and shut it down again.
+runPortMidiT :: MonadIO m => PortMidiT m a -> ExceptT PMError m a
+runPortMidiT PortMidiT { .. } = ExceptT $ do
+  liftIO initialize
+  a <- runExceptT unPortMidi
+  liftIO $ void terminate
+  return a
+
+instance (Launchable m, MonadIO m) => Launchable (PortMidiT m) where
+  runIO liveProgram = runIO $ foreverCLiveProgram $ do
+    e <- LiveProgram.try $ hoistLiveProgram unPortMidi liveProgram
+    once $ liftIO $ do
+      putStrLn "Encountered PortMidi exception:"
+      print e
+    return e
+    where
+      -- Will be part of essence-of-live-coding-0.2.6
+      once :: (Monad m, Data e, Finite e) => m e -> LiveProgram.LiveProgramExcept m e
+      once action = LiveProgram.try $ liveCell $ constM $ ExceptT $ Left <$> action
+
+deriving instance Data PMError
+deriving instance Generic PMError
+instance Finite PMError
+
+-- | A marker to make sure that PortMidi was initialized
+data PortMidiHandle = PortMidiHandle
+
+portMidiHandle :: MonadIO m => Handle m PortMidiHandle
+portMidiHandle = Handle
+  { create = do
+      liftIO initialize
+      return PortMidiHandle
+  , destroy = const $ liftIO $ void terminate
+  }
+
+newtype PortMidiInputStream (name :: Symbol) = PortMidiInputStream { unPortMidiInputStream :: PMStream }
+
+portMidiInputStreamAtProxyName :: Proxy name -> PMStream -> PortMidiInputStream name
+portMidiInputStreamAtProxyName _ = PortMidiInputStream
+
+portMidiInput
+  :: (MonadIO m, KnownSymbol name)
+  => PortMidiHandle
+  -> Handle m (Maybe (PortMidiInputStream (name :: Symbol)))
+portMidiInput _ = portMidiInputWithProxy Proxy
+
+portMidiInputWithProxy
+  :: (MonadIO m, KnownSymbol name)
+  => Proxy (name :: Symbol)
+  -> Handle m (Maybe (PortMidiInputStream (name :: Symbol)))
+portMidiInputWithProxy proxy = Handle
+  { create = liftIO $ do
+      nDevices <- countDevices
+      devices <- forM [0..nDevices-1] $ \deviceID -> do
+        DeviceInfo { .. } <- getDeviceInfo deviceID
+        return (name, deviceID)
+      let deviceID = lookup (symbolVal proxy) devices
+      pmStreamE <- mapM openInput deviceID
+      let pmStream = either (const Nothing) Just =<< pmStreamE
+      return $ portMidiInputStreamAtProxyName proxy <$> pmStream
+  , destroy = maybe (return ()) $ liftIO . void . close . unPortMidiInputStream
+  }
+
+handlingPortMidiInput :: (MonadIO m, KnownSymbol name) => Cell (HandlingStateT m) PortMidiHandle (Maybe (PortMidiInputStream (name :: Symbol)))
+handlingPortMidiInput = handling $ portMidiInputWithProxy Proxy

--- a/essence-of-live-coding-vivid/CHANGELOG.md
+++ b/essence-of-live-coding-vivid/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for essence-of-live-coding-vivid
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/essence-of-live-coding-vivid/essence-of-live-coding-vivid.cabal
+++ b/essence-of-live-coding-vivid/essence-of-live-coding-vivid.cabal
@@ -1,0 +1,38 @@
+cabal-version:      2.4
+name:               essence-of-live-coding-vivid
+version:            0.1.0.0
+
+-- A short (one-line) description of the package.
+-- synopsis:
+
+-- A longer description of the package.
+-- description:
+
+-- A URL where users can report bugs.
+-- bug-reports:
+
+-- The license under which the package is released.
+-- license:
+author:             Manuel Bärenz
+maintainer:         programming@manuelbaerenz.de
+
+-- A copyright notice.
+-- copyright:
+-- category:
+extra-source-files: CHANGELOG.md
+
+library
+    exposed-modules:
+        LiveCoding.Vivid
+
+    -- Modules included in this library but not exported.
+    -- other-modules:
+
+    -- LANGUAGE extensions used by modules in this package.
+    -- other-extensions:
+    build-depends:
+        base >= 4.7
+      , vivid
+      , essence-of-live-coding >= 0.2.4
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
+++ b/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
@@ -22,7 +22,7 @@ data SynthState
 -- fixme release instead of free?
 vividHandleParametrised
   :: (VividAction m, Eq params, VarList params, Subset (InnerVars params) args)
-  => ParametrisedHandle m (params, SynthDef args, SynthState) (Maybe (Synth args))
+  => ParametrisedHandle (params, SynthDef args, SynthState) m (Maybe (Synth args))
 vividHandleParametrised = ParametrisedHandle { .. }
   where
     createParametrised (params, synthDef, Started) = Just <$> synth synthDef params

--- a/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
+++ b/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+module LiveCoding.Vivid where
+
+-- base
+import Data.Foldable (traverse_)
+
+-- vivid
+import Vivid
+
+-- essence-of-live-coding
+import LiveCoding.Handle
+import LiveCoding
+
+data SynthState
+  = Started
+  | Stopped
+  deriving (Eq)
+
+-- fixme release instead of free?
+vividHandleParametrised
+  :: (VividAction m, Eq params, VarList params, Subset (InnerVars params) args)
+  => ParametrisedHandle m (params, SynthDef args, SynthState) (Maybe (Synth args))
+vividHandleParametrised = ParametrisedHandle { .. }
+  where
+    createParametrised (params, synthDef, Started) = Just <$> synth synthDef params
+    createParametrised (params, synthDef, Stopped) = defineSD synthDef >> pure Nothing
+
+    destroyParametrised _ synthMaybe = traverse_ free synthMaybe
+
+    -- Only the synth parameters changed and it's still running.
+    -- So simply set new parameters without stopping it.
+    changeParametrised (paramsOld, synthDefOld, Started) (paramsNew, synthDefNew, Started) (Just synth)
+      | paramsOld /= paramsNew && synthDefOld == synthDefNew = do
+          set synth paramsNew
+          return $ Just synth
+    -- Synthdef or start/stop state changed, need to release and reinitialise
+    changeParametrised old new synth = defaultChange createParametrised destroyParametrised old new synth
+
+deriving instance Eq (SynthDef args)
+
+liveSynth
+  :: (VividAction m, VarList params, Subset (InnerVars params) args, Typeable args, Data params, Eq params, VarList (Synth args))
+  => Cell (HandlingStateT m) (params, SynthDef args, SynthState) (Maybe (Synth args))
+liveSynth = handlingParametrised vividHandleParametrised

--- a/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
+++ b/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
@@ -19,16 +19,15 @@ data SynthState
   | Stopped
   deriving (Eq)
 
--- fixme release instead of free?
 vividHandleParametrised
-  :: (VividAction m, Eq params, VarList params, Subset (InnerVars params) args)
+  :: (VividAction m, Eq params, VarList params, Subset (InnerVars params) args, Elem "gate" args)
   => ParametrisedHandle (params, SynthDef args, SynthState) m (Maybe (Synth args))
 vividHandleParametrised = ParametrisedHandle { .. }
   where
     createParametrised (params, synthDef, Started) = Just <$> synth synthDef params
     createParametrised (params, synthDef, Stopped) = defineSD synthDef >> pure Nothing
 
-    destroyParametrised _ synthMaybe = traverse_ free synthMaybe
+    destroyParametrised _ synthMaybe = traverse_ release synthMaybe
 
     -- Only the synth parameters changed and it's still running.
     -- So simply set new parameters without stopping it.
@@ -42,6 +41,6 @@ vividHandleParametrised = ParametrisedHandle { .. }
 deriving instance Eq (SynthDef args)
 
 liveSynth
-  :: (VividAction m, VarList params, Subset (InnerVars params) args, Typeable args, Data params, Eq params, VarList (Synth args))
+  :: (VividAction m, VarList params, Subset (InnerVars params) args, Typeable args, Data params, Eq params, VarList (Synth args), Elem "gate" args)
   => Cell (HandlingStateT m) (params, SynthDef args, SynthState) (Maybe (Synth args))
 liveSynth = handlingParametrised vividHandleParametrised

--- a/essence-of-live-coding/essence-of-live-coding.cabal
+++ b/essence-of-live-coding/essence-of-live-coding.cabal
@@ -87,6 +87,7 @@ library
     , vector-sized >= 1.2
     , foreign-store >= 0.2
     , time >= 1.9
+    , mmorph >= 1.1
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions: StrictData

--- a/essence-of-live-coding/src/LiveCoding/CellExcept.lhs
+++ b/essence-of-live-coding/src/LiveCoding/CellExcept.lhs
@@ -103,5 +103,13 @@ discardVoid
   = fmap (either absurd id) . runExceptT
 safe :: Monad m => Cell m a b -> CellExcept m a b Void
 safe cell = try $ liftCell cell
+
+-- | Run a monadic action and immediately raise its result as an exception.
+once :: (Monad m, Data e, Finite e) => (a -> m e) -> CellExcept m a arbitrary e
+once kleisli = try $ arrM $ ExceptT . (Left <$>) . kleisli
+
+-- | Like 'once', but the action does not have an input.
+once_ :: (Monad m, Data e, Finite e) => m e -> CellExcept m a arbitrary e
+once_ = once . const
 \end{code}
 \end{comment}

--- a/essence-of-live-coding/src/LiveCoding/Exceptions.lhs
+++ b/essence-of-live-coding/src/LiveCoding/Exceptions.lhs
@@ -64,6 +64,12 @@ throwIf condition e = proc a -> do
 
 throwIf_ :: Monad m => (a -> Bool) -> Cell (ExceptT () m) a a
 throwIf_ condition = throwIf condition ()
+
+inExceptT :: Monad m => Cell (ExceptT e m) (Either e a) a
+inExceptT = proc ea -> do
+  case ea of
+    Left e -> throwC -< e
+    Right a -> returnA -< a
 \end{code}
 \end{comment}
 

--- a/essence-of-live-coding/src/LiveCoding/Handle.hs
+++ b/essence-of-live-coding/src/LiveCoding/Handle.hs
@@ -3,10 +3,13 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 module LiveCoding.Handle where
 
 -- base
+import Control.Arrow ((>>>), arr, returnA)
+import Control.Monad (join, unless)
 import Data.Data
 
 -- transformers
@@ -14,8 +17,9 @@ import Control.Monad.Trans.Class (MonadTrans(lift))
 
 -- essence-of-live-coding
 import LiveCoding.Cell
+import LiveCoding.Cell.Feedback
+import LiveCoding.Cell.Resample (resampleMaybe)
 import LiveCoding.HandlingState
-import Control.Arrow ((>>>), arr)
 
 {- | Container for unserialisable values,
 such as 'IORef's, threads, 'MVar's, pointers, and device handles.
@@ -150,3 +154,34 @@ toParametrised Handle { .. } = ParametrisedHandle
   , changeParametrised = const $ const return
   , destroyParametrised = const destroy
   }
+
+{- | Perform an action whenever the parameter @p@ changes, and the code is reloaded.
+
+Note that this does not trigger any actions when adding, or removing an 'onChange' cell.
+For this functionality, see "LiveCoding.Handle".
+Also, when moving such a cell, the action may not be triggered reliably.
+-}
+onChange
+  :: (Monad m, Data p, Eq p)
+  => p -- ^ This parameter has to change during live coding to trigger an action
+  -> (p -> p -> a -> m b) -- ^ This action gets passed the old parameter and the new parameter
+  -> Cell m a (Maybe b)
+onChange p action = proc a -> do
+  pCurrent <- arr $ const p -< ()
+  pPrevious <- delay p -< pCurrent
+  arrM $ whenDifferent action -< (pCurrent, pPrevious, a)
+
+-- | Like 'onChange'', but with a dynamic input.
+onChange'
+  :: (Monad m, Data p, Eq p)
+  => (p -> p -> a -> m b) -- ^ This action gets passed the old parameter and the new parameter
+  -> Cell m (p, a) (Maybe b)
+onChange' action = proc (pCurrent, a) -> do
+  pPrevious <- delay Nothing -< Just pCurrent
+  bMaybeMaybe <- resampleMaybe $ arrM $ whenDifferent action -< ( , pCurrent, a) <$> pPrevious
+  returnA -< join bMaybeMaybe
+
+whenDifferent :: (Eq p, Monad m) => (p -> p -> a -> m b) -> (p, p, a) -> m (Maybe b)
+whenDifferent action (pOld, pNew, a)
+  | pOld == pNew = Just <$> action pOld pNew a
+  | otherwise    = return Nothing

--- a/essence-of-live-coding/src/LiveCoding/Handle.hs
+++ b/essence-of-live-coding/src/LiveCoding/Handle.hs
@@ -15,6 +15,9 @@ import Data.Data
 -- transformers
 import Control.Monad.Trans.Class (MonadTrans(lift))
 
+-- mmorph
+import Control.Monad.Morph
+
 -- essence-of-live-coding
 import LiveCoding.Cell
 import LiveCoding.Cell.Feedback
@@ -40,6 +43,12 @@ data Handle m h = Handle
   { create :: m h
   , destroy :: h -> m ()
   }
+
+instance MFunctor Handle where
+  hoist morphism Handle { .. } = Handle
+    { create = morphism create
+    , destroy = morphism . destroy
+    }
 
 {- | Combine two handles to one.
 
@@ -87,6 +96,13 @@ data ParametrisedHandle p m h = ParametrisedHandle
   , changeParametrised :: p -> p -> h -> m h
   , destroyParametrised :: p -> h -> m ()
   }
+
+instance MFunctor (ParametrisedHandle p) where
+  hoist morphism ParametrisedHandle { .. } = ParametrisedHandle
+    { createParametrised = morphism . createParametrised
+    , changeParametrised = ((morphism .) .) . changeParametrised
+    , destroyParametrised = (morphism .) . destroyParametrised
+    }
 
 -- | Given the methods 'createParametrised' and 'destroyParametrised',
 --   build a fitting method for 'changeParametrised' which

--- a/essence-of-live-coding/src/LiveCoding/LiveProgram/Except.hs
+++ b/essence-of-live-coding/src/LiveCoding/LiveProgram/Except.hs
@@ -18,7 +18,7 @@ import Control.Monad.Trans.Reader
 
 -- essence-of-live-coding
 import LiveCoding.Cell (hoistCell, toLiveCell, liveCell, constM)
-import LiveCoding.CellExcept (CellExcept, runCellExcept)
+import LiveCoding.CellExcept (CellExcept, runCellExcept, once_)
 import LiveCoding.Exceptions.Finite (Finite)
 import LiveCoding.Forever
 import LiveCoding.LiveProgram
@@ -84,7 +84,7 @@ safe = LiveProgramExcept . CellExcept.safe . toLiveCell
 
 -- | Run a monadic action and immediately raise its result as an exception.
 once :: (Monad m, Data e, Finite e) => m e -> LiveProgramExcept m e
-once action = try $ liveCell $ constM $ ExceptT $ Left <$> action
+once = LiveProgramExcept . once_
 
 {- | Run a 'LiveProgramExcept' in a loop.
 

--- a/stack.8.10.3.yaml
+++ b/stack.8.10.3.yaml
@@ -4,6 +4,7 @@ packages:
 - essence-of-live-coding
 - essence-of-live-coding-gloss
 - essence-of-live-coding-gloss-example
+- essence-of-live-coding-PortMidi
 - essence-of-live-coding-pulse
 - essence-of-live-coding-pulse-example
 - essence-of-live-coding-quickcheck
@@ -15,9 +16,11 @@ packages:
 extra-deps:
 - Yampa-0.13.1@sha256:4612a2646c27bcd3ac55c90dbc34249303e28aa5b3bc3e0c6fa9ce58b889843c,5436
 - http-client-0.7.8@sha256:ed76dcd7edec3aaebe012541ca0a52594405e9b21d69420d26c0223bc4d5dc82,5400
+- PortMidi-0.2.0.0@sha256:0671e36ec72e95138bf396234b205864a8a6d0ee353e09e01cbfd57004c56f40,2383
 
 nix:
   packages:
+    - alsa-lib
     - libGL
     - libGLU
     - libpulseaudio

--- a/stack.8.6.5.yaml
+++ b/stack.8.6.5.yaml
@@ -27,6 +27,7 @@ extra-deps:
 
 nix:
   packages:
+    - alsa-lib
     - libGL
     - libGLU
     - libpulseaudio

--- a/stack.8.8.4.yaml
+++ b/stack.8.8.4.yaml
@@ -18,6 +18,7 @@ extra-deps:
 
 nix:
   packages:
+    - alsa-lib
     - libGL
     - libGLU
     - libpulseaudio


### PR DESCRIPTION
The defaults passed to the sd function are only used when first sending the synthdef. For creating the synth the params var is used. The default values for the sd function can therefore be derived from params by taking their value on the first tick. This ensures they will not change further which will avoid sending the synthdef again. Only changing sdbody will cause the synthdef to be sent again to scsynth.