### PR TITLE
liveSynth - avoid having to explicitly create synthdef v2

### DIFF
--- a/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
+++ b/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
@@ -6,7 +6,9 @@ With this module, you can create cells corresponding to synthesizers.
 The synthesizers automatically start and stop on reload.
 -}
 
+{-# LANGUAGE Arrows #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -14,6 +16,7 @@ module LiveCoding.Vivid where
 
 -- base
 import Data.Foldable (traverse_)
+import GHC.TypeLits (KnownSymbol)
 
 -- vivid
 import Vivid
@@ -61,8 +64,18 @@ vividHandleParametrised = ParametrisedHandle { .. }
     changeParametrised old new synth = defaultChange createParametrised destroyParametrised old new synth
 
 deriving instance Eq (SynthDef args)
+deriving instance Data SynthState
+deriving instance KnownSymbol a => Data (I a)
 
 liveSynth
-  :: (VividAction m, VarList params, Subset (InnerVars params) args, Typeable args, Data params, Eq params, VarList (Synth args), Elem "gate" args)
-  => Cell (HandlingStateT m) (params, SynthDef args, SynthState) (Maybe (Synth args))
-liveSynth = handlingParametrised vividHandleParametrised
+  :: ( VividAction m
+     , Eq params, Typeable params, VarList params
+     , Typeable (InnerVars params), Subset (InnerVars params) (InnerVars params)
+     , Elem "gate" (InnerVars params), Data params
+     )
+  => Cell (HandlingStateT m)
+       (params, SDBody' (InnerVars params) [Signal], SynthState)
+       (Maybe (Synth (InnerVars params)))
+liveSynth = proc (params, sdbody, synthstate) -> do
+  paramsFirstValue <- hold -< params
+  handlingParametrised vividHandleParametrised -< (params, sd paramsFirstValue sdbody, synthstate)

--- a/essence-of-live-coding/src/LiveCoding/Cell/Util.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/Util.hs
@@ -68,6 +68,14 @@ keepJust = feedback Nothing $ arr keep
     keep (_, Just a) = (Just a, Just a)
     keep (Just a, Nothing) = (Just a, Just a)
 
+-- | Hold the first value and output it indefinitely.
+hold :: (Data a, Monad m) => Cell m a a
+hold = Cell { .. }
+  where
+    cellState = Nothing
+    cellStep Nothing x = return (x, Just x)
+    cellStep (Just s) _ = return (s, Just s)
+
 -- | @boundedFIFO n@ keeps the first @n@ present values.
 boundedFIFO :: (Data a, Monad m) => Int -> Cell m (Maybe a) (Seq a)
 boundedFIFO n = foldC' step empty


### PR DESCRIPTION
The defaults passed to the sd function are only used when first sending the synthdef. For creating the synth the params var is used. The default values for the sd function can therefore be derived from params by taking their value on the first tick. This ensures they will not change further which will avoid sending the synthdef again. Only changing sdbody will cause the synthdef to be sent again to scsynth.