### PR TITLE
relax dependency on http-client in tests of essence-of-live-coding-warp

### DIFF
--- a/essence-of-live-coding-warp/essence-of-live-coding-warp.cabal
+++ b/essence-of-live-coding-warp/essence-of-live-coding-warp.cabal
@@ -55,7 +55,7 @@ test-suite test
   hs-source-dirs: test
   build-depends:
       base >= 4.11 && < 5
-    , http-client >= 0.7.1
+    , http-client >= 0.6.4.1
     , bytestring >= 0.10
     , essence-of-live-coding >= 0.2.5
     , essence-of-live-coding-warp


### PR DESCRIPTION
This PR relaxes the version of `http-client` required by essence-of-live-coding-warp.

It appears that essence-of-live-coding-warp is able to compile with an older version of `http-client`.

I made this change in Nixpkgs https://github.com/NixOS/nixpkgs/pull/137340/commits/02d3bde59a3543532db493a82da6073753e359d4 on PR https://github.com/NixOS/nixpkgs/pull/137340.