### PR TITLE
Add Cell.Migrate.NoMigration module

### DIFF
--- a/essence-of-live-coding/essence-of-live-coding.cabal
+++ b/essence-of-live-coding/essence-of-live-coding.cabal
@@ -64,6 +64,7 @@ library
     , LiveCoding.Migrate
     , LiveCoding.Migrate.Cell
     , LiveCoding.Migrate.Migration
+    , LiveCoding.Migrate.NoMigration
     , LiveCoding.Migrate.Monad.Trans
     , LiveCoding.Migrate.Debugger
     , LiveCoding.RuntimeIO
@@ -98,6 +99,7 @@ test-suite test
   main-is: Main.hs
   other-modules:
       Cell
+    , Migrate.NoMigration
     , Cell.Monad.Trans
     , Cell.Util
     , Feedback

--- a/essence-of-live-coding/src/LiveCoding.hs
+++ b/essence-of-live-coding/src/LiveCoding.hs
@@ -40,5 +40,6 @@ import LiveCoding.LiveProgram.Monad.Trans as X
 import LiveCoding.Migrate as X
 import LiveCoding.Migrate.Debugger as X
 import LiveCoding.Migrate.Migration as X
+import LiveCoding.Migrate.NoMigration as X hiding (delay, changes)
 import LiveCoding.RuntimeIO as X hiding (update)
 import LiveCoding.RuntimeIO.Launch as X hiding (foreground)

--- a/essence-of-live-coding/src/LiveCoding/Handle.hs
+++ b/essence-of-live-coding/src/LiveCoding/Handle.hs
@@ -19,6 +19,7 @@ import Control.Monad.Morph
 -- essence-of-live-coding
 import LiveCoding.Cell
 import LiveCoding.HandlingState
+import LiveCoding.Migrate.NoMigration
 
 {- | Container for unserialisable values,
 such as 'IORef's, threads, 'MVar's, pointers, and device handles.
@@ -148,15 +149,15 @@ handlingParametrised handleImpl@ParametrisedHandle { .. } = Cell { .. }
       mereHandle <- lift $ createParametrised parameter
       let handle = (mereHandle, parameter)
       key <- register $ destroyParametrised parameter mereHandle
-      return (mereHandle, Handling { handle = handle, .. })
-    cellStep handling@Handling { handle = (mereHandle, lastParameter), .. } parameter
+      return (mereHandle, Initialized Handling { handle = handle, .. })
+    cellStep handling@(Initialized Handling { handle = (mereHandle, lastParameter), .. }) parameter
       | parameter == lastParameter = do
           reregister (destroyParametrised parameter mereHandle) key
           return (mereHandle, handling)
       | otherwise = do
           mereHandle <- lift $ changeParametrised lastParameter parameter mereHandle
           reregister (destroyParametrised parameter mereHandle) key
-          return (mereHandle, Handling { handle = (mereHandle, parameter), .. })
+          return (mereHandle, Initialized Handling { handle = (mereHandle, parameter), .. })
 
 -- | Every 'Handle' is trivially a 'ParametrisedHandle'
 --   when the parameter is the trivial type.

--- a/essence-of-live-coding/src/LiveCoding/HandlingState.hs
+++ b/essence-of-live-coding/src/LiveCoding/HandlingState.hs
@@ -25,13 +25,10 @@ import LiveCoding.Cell.Monad.Trans
 import LiveCoding.LiveProgram
 import LiveCoding.LiveProgram.Monad.Trans
 
-data Handling h where
-  Handling
-    :: { key    :: Key
-       , handle :: h
-       }
-    -> Handling h
-  Uninitialized :: Handling h
+data Handling h = Handling
+  { key    :: Key
+  , handle :: h
+  }
 
 type Destructors m = IntMap (Destructor m)
 
@@ -153,22 +150,6 @@ destroyUnregistered = do
   put HandlingState { destructors = registered, .. }
 
 -- * 'Data' instances
-
-dataTypeHandling :: DataType
-dataTypeHandling = mkDataType "Handling" [handlingConstr, uninitializedConstr]
-
-handlingConstr :: Constr
-handlingConstr = mkConstr dataTypeHandling "Handling" [] Prefix
-
-uninitializedConstr :: Constr
-uninitializedConstr = mkConstr dataTypeHandling "Uninitialized" [] Prefix
-
-instance (Typeable h) => Data (Handling h) where
-  dataTypeOf _ = dataTypeHandling
-  toConstr Handling { .. } = handlingConstr
-  toConstr Uninitialized = uninitializedConstr
-  gunfold _cons nil constructor = nil Uninitialized
-
 dataTypeDestructor :: DataType
 dataTypeDestructor = mkDataType "Destructor" [ destructorConstr ]
 

--- a/essence-of-live-coding/src/LiveCoding/Migrate/NoMigration.hs
+++ b/essence-of-live-coding/src/LiveCoding/Migrate/NoMigration.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE Arrows #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-|
+Module      : LiveCoding.Migrate.NoMigration
+Description : Mechanism to save state in a Cell without requiring a Data instance.
+
+If a data type is wrapped in 'NoMigration' then it can be used as the state of a 'Cell'
+without requiring it to have a 'Data' instance. The consequence is that if the type has changed
+in between a livereload, then the previous saved value will be discarded, and no migration attempt
+will happen.
+
+'LiveCoding' does not export 'delay' and 'changes' from this module. These functions should be
+used with a qualified import.
+-}
+module LiveCoding.Migrate.NoMigration where
+
+-- base
+import Data.Data
+    ( Data(dataTypeOf, gunfold, toConstr),
+      Typeable,
+      mkConstr,
+      mkDataType,
+      Constr,
+      DataType,
+      Fixity(Prefix) )
+import Control.Arrow ( Arrow(arr, second), returnA, (>>>) )
+import Control.Monad (guard)
+
+-- essence-of-live-coding
+import LiveCoding.Cell
+import LiveCoding.Cell.Monad ( hoistCellKleisli )
+import qualified LiveCoding.Cell.Feedback as Feedback
+
+-- * 'NoMigration' data type and 'Data' instance.
+
+-- | Isomorphic to @'Maybe' a@ but has a different 'Data' instance. The 'Data' instance for @'NoMigration' a@ doesn't require a 'Data' instance for @a@.
+-- 
+-- If a data type is wrapped in 'NoMigration' then it can be used as the state of a 'Cell'
+-- without requiring it to have a 'Data' instance. The consequence is that if the type has changed
+-- in between a livereload, then the previous saved value will be discarded, and no migration attempt
+-- will happen.
+data NoMigration a = Initialized a | Uninitialized
+    deriving (Show, Eq, Functor, Foldable, Traversable)
+
+fromNoMigration :: a -> NoMigration a -> a
+fromNoMigration _ (Initialized a) = a
+fromNoMigration a Uninitialized = a
+
+dataTypeNoMigration :: DataType
+dataTypeNoMigration = mkDataType "NoMigration" [initializedConstr, uninitializedConstr]
+
+initializedConstr :: Constr
+initializedConstr = mkConstr dataTypeNoMigration "Initialized" [] Prefix
+
+uninitializedConstr :: Constr
+uninitializedConstr = mkConstr dataTypeNoMigration "Uninitialized" [] Prefix
+
+-- |The Data instance for @'NoMigration' a@ doesn't require a 'Data' instance for @a@.
+instance (Typeable a) => Data (NoMigration a)
+  where
+    dataTypeOf _ = dataTypeNoMigration
+    toConstr (Initialized _) = initializedConstr
+    toConstr Uninitialized = uninitializedConstr
+    gunfold _cons nil _ = nil Uninitialized
+
+-- * Utility functions which internally use 'NoMigration'.
+
+-- | Like 'Feedback.delay', but doesn't require 'Data' instance, and only migrates the
+-- last value if it still has the same type.
+delay :: (Monad m, Typeable a) => a -> Cell m a a
+delay a = arr Initialized >>> Feedback.delay Uninitialized >>> arr (fromNoMigration a)
+
+-- | Like 'Utils.changes', but doesn't require Data instance, and only migrates the last
+-- value if it still is of the same type.
+changes :: (Typeable a, Eq a, Monad m) => Cell m a (Maybe a)
+changes = proc a -> do
+  aLast <- delay Nothing -< Just a
+  returnA -< do
+      aLast' <- aLast
+      guard $ a /= aLast'
+      return a
+
+-- | Caching version of 'arrM'. 
+--
+--   Only runs the computation in @m@ when the input value
+--   changes. Meanwhile it keeps outputing the last outputted value. Also runs the computation
+--   on the first tick. Does not require 'Data' instance. On `:livereload` will run action again on
+--   first tick.
+arrChangesM :: (Monad m, Typeable a, Typeable b, Eq a) => (a -> m b) -> Cell m a b
+arrChangesM f = Cell { cellState = Uninitialized, ..}
+  where
+    cellStep Uninitialized        a = h a
+    cellStep (Initialized (a',b)) a = if a == a'
+      then return (b, Initialized (a, b))
+      else h a
+    h a = (\b' -> (b', Initialized (a, b') )) <$> f a
+
+cellNoMigration :: (Typeable s, Functor m) => s -> (s -> a -> m (b, s)) -> Cell m a b
+cellNoMigration state step = Cell { cellState = Uninitialized, ..}
+  where
+    cellStep Uninitialized a = second Initialized <$> step state a
+    cellStep (Initialized s) a = second Initialized <$> step s a

--- a/essence-of-live-coding/test/Cell/Util.hs
+++ b/essence-of-live-coding/test/Cell/Util.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Cell.Util where
 
 -- base
@@ -118,6 +119,22 @@ test = testGroup "Utility unit tests"
     , output1 = [Nothing, Just 2]
     , output2 = [Just 3, Just 4]
     }
+  , testProperty "delay migrates correctly to itself" CellMigrationSimulation
+    { cell1 = LiveCoding.delay 0
+    , cell2 = LiveCoding.delay 0
+    , input1 = [1 :: Int, 2, 3, 4]
+    , input2 = [5 :: Int, 6, 7, 8]
+    , output1 = [0, 1, 2, 3]
+    , output2 = [4, 5, 6, 7]
+    }
+  , testProperty "delay migrates correctly with original type wrapped in data type with single constructor" CellMigrationSimulation
+    { cell1 = LiveCoding.delay 0 :: Cell Identity Int Int
+    , cell2 = arr Stuff >>> LiveCoding.delay (Stuff 99) >>> arr (\(Stuff a) -> a) :: Cell Identity Int Int
+    , input1 = [1, 2, 3, 4] :: [Int]
+    , input2 = [10, 10, 10, 10] :: [Int]
+    , output1 = [0, 1, 2, 3] :: [Int]
+    , output2 = [4, 10, 10, 10] :: [Int]
+    }
   , testProperty "resampleListPar works as expected"
     $ forAll (vector 100) $ \(inputs :: [(Int, Int)]) -> let
         inputs' = fmap pairToList inputs
@@ -150,3 +167,5 @@ test = testGroup "Utility unit tests"
     , output = [[0,0,0],[1,1],[2,2,0]]
     }
   ]
+
+data Stuff a = Stuff a deriving (Eq, Data)

--- a/essence-of-live-coding/test/Main.hs
+++ b/essence-of-live-coding/test/Main.hs
@@ -23,6 +23,7 @@ import qualified Handle
 import qualified Monad
 import qualified Monad.Trans
 import qualified RuntimeIO.Launch
+import qualified Migrate.NoMigration
 
 import LiveCoding
 
@@ -115,6 +116,7 @@ tests =
       ]
     , Cell.test
     , Handle.test
+    , Migrate.NoMigration.test
     , Monad.test
     , Feedback.test
     ]

--- a/essence-of-live-coding/test/Migrate/NoMigration.hs
+++ b/essence-of-live-coding/test/Migrate/NoMigration.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Migrate.NoMigration where
+
+-- base
+import Control.Arrow ( Arrow(arr), (>>>) )
+import Data.Maybe (fromJust)
+import Data.Data (Data)
+
+-- test-framework
+import Test.Framework ( testGroup )
+
+-- test-framework-quickcheck2
+import Test.Framework.Providers.QuickCheck2 ( testProperty )
+
+-- essence-of-live-coding
+import Util
+import qualified LiveCoding.Migrate.NoMigration as NoMigration
+
+data Stuff a = Stuff a deriving (Eq, Data)
+
+test = testGroup "NoMigration unit tests"
+  [ testProperty "LiveCoding.Migrate.NoMigration.delay migrates correctly to itself" CellMigrationSimulation
+    { cell1 = NoMigration.delay 0
+    , cell2 = NoMigration.delay 0
+    , input1 = [1 :: Int, 2, 3, 4]
+    , input2 = [5 :: Int, 6, 7, 8]
+    , output1 = [0, 1, 2, 3]
+    , output2 = [4, 5, 6, 7]
+    }
+  , testProperty "LiveCoding.Migrate.NoMigration.delay different type will not migrate" CellMigrationSimulation
+    { cell1 = NoMigration.delay 0
+    , cell2 = arr Stuff >>> NoMigration.delay (Stuff 99) >>> arr (\(Stuff a) -> a)
+    , input1 = [1 :: Int, 2, 3, 4]
+    , input2 = [10 :: Int, 10, 10, 10]
+    , output1 = [0, 1, 2, 3]
+    , output2 = [99, 10, 10, 10]
+     }
+  ]


### PR DESCRIPTION
This generalizes the mechanism used by Handles to forgo migration, so that it can be used by other code.

It adds `delay` and `changes` versions that don't require a Data instance.
It adds `arrChangesM` which only runs an action when a value changes and also doesn't require a Data instance. After migration the kleisli function is called again to get a new value. 

