### PR TITLE
add resampleListPar

### DIFF
--- a/essence-of-live-coding/src/LiveCoding/Cell/Resample.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/Resample.hs
@@ -16,7 +16,7 @@ import Data.Maybe
 import GHC.TypeNats
 
 -- vector-sized
-import Data.Vector.Sized
+import Data.Vector.Sized ( fromList, toList, Vector )
 
 -- essence-of-live-coding
 import LiveCoding.Cell
@@ -45,9 +45,9 @@ resampleMaybe cell = arr maybeToList >>> resampleList cell >>> arr listToMaybe
 --
 -- Similar to Yampa's [parC](https://hackage.haskell.org/package/Yampa-0.13.3/docs/FRP-Yampa-Switches.html#v:parC).
 resampleListPar :: Monad m => Cell m a b -> Cell m [a] [b]
-resampleListPar (Cell initial step) = Cell cellState' cellStep' where
-    cellState' = []
-    cellStep' s xs = Prelude.unzip <$> traverse (uncurry step) (Prelude.zip s' xs)
+resampleListPar (Cell initial step) = Cell { .. } where
+    cellState = []
+    cellStep s xs = unzip <$> traverse (uncurry step) (zip s' xs)
         where
-            s' = s Prelude.++ Prelude.replicate (Prelude.length xs - Prelude.length s) initial
+            s' = s ++ replicate (length xs - length s) initial
 resampleListPar (ArrM f) = ArrM (traverse f)

--- a/essence-of-live-coding/src/LiveCoding/Cell/Resample.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/Resample.hs
@@ -38,3 +38,16 @@ resampleList = hoistCellKleisli morph
 
 resampleMaybe :: Monad m => Cell m a b -> Cell m (Maybe a) (Maybe b)
 resampleMaybe cell = arr maybeToList >>> resampleList cell >>> arr listToMaybe
+
+-- | Create as many cells as the input list is long and execute them in parallel 
+-- (in the sense that each one has a separate state). At each tick the list with
+-- the different states grows or shrinks depending on the size of the input list.
+--
+-- Similar to Yampa's [parC](https://hackage.haskell.org/package/Yampa-0.13.3/docs/FRP-Yampa-Switches.html#v:parC).
+resampleListPar :: Monad m => Cell m a b -> Cell m [a] [b]
+resampleListPar (Cell initial step) = Cell cellState' cellStep' where
+    cellState' = []
+    cellStep' s xs = Prelude.unzip <$> traverse (uncurry step) (Prelude.zip s' xs)
+        where
+            s' = s Prelude.++ Prelude.replicate (Prelude.length xs - Prelude.length s) initial
+resampleListPar (ArrM f) = ArrM (traverse f)

--- a/essence-of-live-coding/src/LiveCoding/Cell/Resample.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/Resample.hs
@@ -46,8 +46,8 @@ resampleMaybe cell = arr maybeToList >>> resampleList cell >>> arr listToMaybe
 -- Similar to Yampa's [parC](https://hackage.haskell.org/package/Yampa-0.13.3/docs/FRP-Yampa-Switches.html#v:parC).
 resampleListPar :: Monad m => Cell m a b -> Cell m [a] [b]
 resampleListPar (Cell initial step) = Cell { .. } where
-    cellState = []
-    cellStep s xs = unzip <$> traverse (uncurry step) (zip s' xs)
-        where
-            s' = s ++ replicate (length xs - length s) initial
+  cellState = []
+  cellStep s xs = unzip <$> traverse (uncurry step) (zip s' xs)
+    where
+      s' = s ++ replicate (length xs - length s) initial
 resampleListPar (ArrM f) = ArrM (traverse f)

--- a/essence-of-live-coding/test/Cell.hs
+++ b/essence-of-live-coding/test/Cell.hs
@@ -27,6 +27,10 @@ import qualified Cell.Monad.Trans
 test = testGroup "Cell"
   [ testProperty "steps produces outputs"
     $ \(inputs :: [Int]) -> inputs === fst (runIdentity $ steps (id :: Cell Identity Int Int) inputs)
+  , testProperty "sumC works as expected"
+    $ forAll (vector 100) $ \(inputs :: [Int]) ->
+        sum (init inputs) ===
+          last (fst (runIdentity $ steps (sumC :: Cell Identity Int Int) inputs))
   , Cell.Util.test
   , Cell.Monad.Trans.test
   ]

--- a/essence-of-live-coding/test/Cell/Util.hs
+++ b/essence-of-live-coding/test/Cell/Util.hs
@@ -119,26 +119,34 @@ test = testGroup "Utility unit tests"
     , output2 = [Just 3, Just 4]
     }
   , testProperty "resampleListPar works as expected"
-    $ forAll (vector 100) $ \(inputs :: [(Int, Int)]) -> let 
+    $ forAll (vector 100) $ \(inputs :: [(Int, Int)]) -> let
         inputs' = fmap pairToList inputs
         pairToList :: (a, a) -> [a]
         pairToList (x,y) = [x,y]
-      in fmap sum (transpose (init inputs')) ===
-        last (fst (runIdentity $ steps (resampleListPar (sumC :: Cell Identity Int Int)) inputs'))
-  , testProperty "resampleListPar grow"
-    $ CellSimulation (resampleListPar (sumC :: Cell Identity Int Int))
-        [[1,1,1],[1,1,1],[1,1,1,1],[1,1,1,1],[1,1,1,1,1]]
-        [[0,0,0],[1,1,1],[2,2,2,0],[3,3,3,1],[4,4,4,2,0]]
-  , testProperty "resampleListPar shrink"
-    $ CellSimulation (resampleListPar (sumC :: Cell Identity Int Int))
-        [[1,1,1],[1,1,1],[1,1],[1,1],[1],[]]
-        [[0,0,0],[1,1,1],[2,2],[3,3],[4],[]]
-  , testProperty "resampleListPar grow then shrink"
-    $ CellSimulation (resampleListPar (sumC :: Cell Identity Int Int))
-        [[1,1,1],[1,1,1,1],[1,1,1]]
-        [[0,0,0],[1,1,1,0],[2,2,2]]
-  , testProperty "resampleListPar shrink then grow"
-    $ CellSimulation (resampleListPar (sumC :: Cell Identity Int Int))
-        [[1,1,1],[1,1],[1,1,1]]
-        [[0,0,0],[1,1],[2,2,0]]
+      in 
+        CellSimulation
+        { cell = resampleListPar (sumC :: Cell Identity Int Int)
+        , input = inputs'
+        , output = fmap sum . transpose <$> [[0::Int,0]] : tail (inits (init inputs'))
+        }
+  , testProperty "resampleListPar grow" CellSimulation
+    { cell = resampleListPar (sumC :: Cell Identity Int Int)
+    , input = [[1,1,1],[1,1,1],[1,1,1,1],[1,1,1,1],[1,1,1,1,1]]
+    , output = [[0,0,0],[1,1,1],[2,2,2,0],[3,3,3,1],[4,4,4,2,0]]
+    }
+  , testProperty "resampleListPar shrink" CellSimulation
+    { cell = resampleListPar (sumC :: Cell Identity Int Int)
+    , input = [[1,1,1],[1,1,1],[1,1],[1,1],[1],[]]
+    , output = [[0,0,0],[1,1,1],[2,2],[3,3],[4],[]]
+    }
+  , testProperty "resampleListPar grow then shrink" CellSimulation
+    { cell = resampleListPar (sumC :: Cell Identity Int Int)
+    , input = [[1,1,1],[1,1,1,1],[1,1,1]]
+    , output = [[0,0,0],[1,1,1,0],[2,2,2]]
+    }
+  , testProperty "resampleListPar shrink then grow" CellSimulation
+    { cell = resampleListPar (sumC :: Cell Identity Int Int)
+    , input = [[1,1,1],[1,1],[1,1,1]]
+    , output = [[0,0,0],[1,1],[2,2,0]]
+    }
   ]

--- a/essence-of-live-coding/test/Cell/Util.hs
+++ b/essence-of-live-coding/test/Cell/Util.hs
@@ -7,6 +7,7 @@ import qualified Control.Category as C
 import Data.Functor.Identity
 import Data.Maybe
 import Control.Monad
+import Data.List
 
 -- transformers
 import Control.Monad.Trans.Reader
@@ -117,4 +118,11 @@ test = testGroup "Utility unit tests"
     , output1 = [Nothing, Just 2]
     , output2 = [Just 3, Just 4]
     }
+    , testProperty "resampleListPar works as expected"
+    $ forAll (vector 100) $ \(inputs :: [(Int, Int)]) -> let inputs' = fmap pairToList inputs  in
+        fmap sum (transpose (init inputs')) ===
+          last (fst (runIdentity $ steps (resampleListPar (sumC :: Cell Identity Int Int)) inputs'))
   ]
+
+pairToList :: (a, a) -> [a]
+pairToList (x,y) = [x,y]

--- a/essence-of-live-coding/test/Cell/Util.hs
+++ b/essence-of-live-coding/test/Cell/Util.hs
@@ -118,11 +118,27 @@ test = testGroup "Utility unit tests"
     , output1 = [Nothing, Just 2]
     , output2 = [Just 3, Just 4]
     }
-    , testProperty "resampleListPar works as expected"
-    $ forAll (vector 100) $ \(inputs :: [(Int, Int)]) -> let inputs' = fmap pairToList inputs  in
-        fmap sum (transpose (init inputs')) ===
-          last (fst (runIdentity $ steps (resampleListPar (sumC :: Cell Identity Int Int)) inputs'))
+  , testProperty "resampleListPar works as expected"
+    $ forAll (vector 100) $ \(inputs :: [(Int, Int)]) -> let 
+        inputs' = fmap pairToList inputs
+        pairToList :: (a, a) -> [a]
+        pairToList (x,y) = [x,y]
+      in fmap sum (transpose (init inputs')) ===
+        last (fst (runIdentity $ steps (resampleListPar (sumC :: Cell Identity Int Int)) inputs'))
+  , testProperty "resampleListPar grow"
+    $ CellSimulation (resampleListPar (sumC :: Cell Identity Int Int))
+        [[1,1,1],[1,1,1],[1,1,1,1],[1,1,1,1],[1,1,1,1,1]]
+        [[0,0,0],[1,1,1],[2,2,2,0],[3,3,3,1],[4,4,4,2,0]]
+  , testProperty "resampleListPar shrink"
+    $ CellSimulation (resampleListPar (sumC :: Cell Identity Int Int))
+        [[1,1,1],[1,1,1],[1,1],[1,1],[1],[]]
+        [[0,0,0],[1,1,1],[2,2],[3,3],[4],[]]
+  , testProperty "resampleListPar grow then shrink"
+    $ CellSimulation (resampleListPar (sumC :: Cell Identity Int Int))
+        [[1,1,1],[1,1,1,1],[1,1,1]]
+        [[0,0,0],[1,1,1,0],[2,2,2]]
+  , testProperty "resampleListPar shrink then grow"
+    $ CellSimulation (resampleListPar (sumC :: Cell Identity Int Int))
+        [[1,1,1],[1,1],[1,1,1]]
+        [[0,0,0],[1,1],[2,2,0]]
   ]
-
-pairToList :: (a, a) -> [a]
-pairToList (x,y) = [x,y]


### PR DESCRIPTION
resampleListPar: create as many cells as the input list is long and execute them in parallel
(in the sense that each one has a separate state). At each tick the list with
the different states grows or shrinks depending on the size of the input list.

Similar to Yampa's [parC](https://hackage.haskell.org/package/Yampa-0.13.3/docs/FRP-Yampa-Switches.html#v:parC).