### PR TITLE
Investigate the possibility of using ormolu for formatting

### DIFF
--- a/demos/Setup.hs
+++ b/demos/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/demos/app/DemoSine.hs
+++ b/demos/app/DemoSine.hs
@@ -3,6 +3,7 @@ import LiveCoding
 
 t1 :: Num a => a
 t1 = 4
+
 t2 :: Num a => a
 t2 = 8
 

--- a/demos/app/DemoSineWaitChange.hs
+++ b/demos/app/DemoSineWaitChange.hs
@@ -1,17 +1,18 @@
 -- base
 import Control.Arrow
-
 -- essence-of-live-coding
 import LiveCoding
 
 t1 :: Num a => a
 t1 = 8
+
 t2 :: Num a => a
 t2 = 4
 
-printSineWait' t = liveCell
-  $   safely (sineWait t)
-  >>> printEverySecond
+printSineWait' t =
+  liveCell $
+    safely (sineWait t)
+      >>> printEverySecond
 
 main = do
   (debugger, observer) <- countDebugger

--- a/demos/app/DemoSinesForever.hs
+++ b/demos/app/DemoSinesForever.hs
@@ -5,4 +5,5 @@ main = do
   (debugger, observer) <- countDebugger
   var <- launchWithDebugger printSinesForever $ debugger
   await observer $ 12 * stepRate
-  --putStrLn "[...]"
+
+-- putStrLn "[...]"

--- a/demos/app/DemoWai.hs
+++ b/demos/app/DemoWai.hs
@@ -5,41 +5,39 @@
 -- base
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
-
 -- transformers
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Reader
-
 -- bytestring
 import Data.ByteString.Lazy.Char8 (pack)
-
 -- wai
+
+-- essence-of-live-coding
+
+import DemoWai.DemoWai1 (oldServer)
+import DemoWai.DemoWai2 (newServer)
+import DemoWai.Env
+import LiveCoding
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Handler.Warp (run)
 
--- essence-of-live-coding
-import LiveCoding
-
-import DemoWai.Env
-import DemoWai.DemoWai1 (oldServer)
-import DemoWai.DemoWai2 (newServer)
-
 app :: Env -> Application
-app Env { .. } request respond = do
+app Env {..} request respond = do
   putMVar requestVar request
   response <- takeMVar responseVar
-  respond $ responseLBS
-        status200
-        [("Content-Type", "text/plain")]
-        $ pack response
+  respond $
+    responseLBS
+      status200
+      [("Content-Type", "text/plain")]
+      $ pack response
 
 main :: IO ()
 main = do
   putStrLn "Let's go!"
   responseVar <- newEmptyMVar
   requestVar <- newEmptyMVar
-  let env = Env { .. }
+  let env = Env {..}
   launchedProgram <- launch $ hoistLiveProgram (flip runReaderT env) oldServer
   forkIO $ run 8080 $ app env
   _ <- getLine

--- a/demos/app/Examples.hs
+++ b/demos/app/Examples.hs
@@ -1,33 +1,36 @@
 {-# LANGUAGE Arrows #-}
+
 module Examples where
 
 -- base
 import Control.Arrow
 import Control.Concurrent
-
 -- essence-of-live-coding
 import LiveCoding
 
 countUpTo :: Monad m => Integer -> Cell (ExceptT () m) a Integer
-countUpTo     n = arr (const   1 ) >>> sumFrom 0 >>> throwIf_ (>= n)
+countUpTo n = arr (const 1) >>> sumFrom 0 >>> throwIf_ (>= n)
 
 countDownFrom :: Monad m => Integer -> Cell (ExceptT () m) a Integer
 countDownFrom n = arr (const (-1)) >>> sumFrom n >>> throwIf_ (<= 0)
 
-throwWhenReaches
-  :: Monad m
-  => Integer -> Cell (ExceptT () m) Integer Integer
+throwWhenReaches ::
+  Monad m =>
+  Integer ->
+  Cell (ExceptT () m) Integer Integer
 throwWhenReaches amplitude = proc n -> if n == amplitude then throwC -< () else returnA -< n
 
 saw1 :: Monad m => Integer -> Cell m () Integer
-saw1 amplitude = foreverC $ runCellExcept $ do
-  try $ countUpTo     amplitude
-  try $ countDownFrom amplitude
+saw1 amplitude = foreverC $
+  runCellExcept $ do
+    try $ countUpTo amplitude
+    try $ countDownFrom amplitude
 
 saw2 :: Monad m => Integer -> Cell m () Integer
-saw2 amplitude = foreverC $ runCellExcept $ do
-  try $ countUpTo amplitude
-  try $ countUpTo amplitude
+saw2 amplitude = foreverC $
+  runCellExcept $ do
+    try $ countUpTo amplitude
+    try $ countUpTo amplitude
 
 example1 :: Integer -> LiveProgram IO
 example1 n = liveCell $ sine 1 >>> arrM print >>> constM (threadDelay 10000)
@@ -35,12 +38,11 @@ example1 n = liveCell $ sine 1 >>> arrM print >>> constM (threadDelay 10000)
 example2 :: Integer -> LiveProgram IO
 example2 n = liveCell $ saw2 n >>> arrM print >>> constM (threadDelay 500000)
 
-
 myMapM_ f (a : as) = f a *> myMapM_ f as
 myMapM_ _ [] = return ()
 
 listThing :: Monad m => Cell m a Integer
-listThing = safely $ myMapM_ (try . countUpTo) [3,5,6] *> safe count
+listThing = safely $ myMapM_ (try . countUpTo) [3, 5, 6] *> safe count
 
 example :: LiveProgram IO
 example = liveCell $ listThing >>> arrM print >>> constM (threadDelay 500000)

--- a/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
+++ b/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi.hs
@@ -1,11 +1,3 @@
-{- | * Support for [PortMidi](http://hackage.haskell.org/package/PortMidi)
-
-With this module, you can add cells which receive and send MIDI events.
-
-You don't need to initialise PortMidi, or open devices,
-this is all done by @essence-of-live-coding@ using the "LiveCoding.Handle" mechanism.
--}
-
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
@@ -18,71 +10,75 @@ this is all done by @essence-of-live-coding@ using the "LiveCoding.Handle" mecha
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+
+-- | * Support for [PortMidi](http://hackage.haskell.org/package/PortMidi)
+--
+-- With this module, you can add cells which receive and send MIDI events.
+--
+-- You don't need to initialise PortMidi, or open devices,
+-- this is all done by @essence-of-live-coding@ using the "LiveCoding.Handle" mechanism.
 module LiveCoding.PortMidi where
 
 -- base
 import Control.Concurrent (threadDelay)
-import Control.Monad (void, forM, join)
+import Control.Monad (forM, join, void)
 import Control.Monad.IO.Class (MonadIO (liftIO))
+-- transformers
+import Control.Monad.Trans.Class
 import Data.Either (fromRight)
-import Data.Foldable (traverse_, find)
+import Data.Foldable (find, traverse_)
 import Data.Function ((&))
 import Data.Maybe (catMaybes)
 import GHC.Generics
-import GHC.TypeLits (Symbol, symbolVal, KnownSymbol)
-
--- transformers
-import Control.Monad.Trans.Class
-
+import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 -- PortMidi
-import Sound.PortMidi
 
 -- essence-of-live-coding
 import LiveCoding
-
 -- essence-of-live-coding-PortMidi
 import LiveCoding.PortMidi.Internal
+import Sound.PortMidi
 
 -- * The 'PortMidiT' monad transformer
 
-{- | Monad transformer adding PortMidi-related effects to your monad.
-
-This transformer adds two kinds of effects to your stack:
-
-* PortMidi exceptions (See 'EOLCPortMidiError')
-* Automatic initialisation of PortMidi devices (using 'HandlingStateT')
--}
+-- | Monad transformer adding PortMidi-related effects to your monad.
+--
+-- This transformer adds two kinds of effects to your stack:
+--
+-- * PortMidi exceptions (See 'EOLCPortMidiError')
+-- * Automatic initialisation of PortMidi devices (using 'HandlingStateT')
 newtype PortMidiT m a = PortMidiT
-  { unPortMidiT :: ExceptT EOLCPortMidiError (HandlingStateT m) a }
+  {unPortMidiT :: ExceptT EOLCPortMidiError (HandlingStateT m) a}
   deriving (Functor, Applicative, Monad, MonadIO)
 
 instance MonadTrans PortMidiT where
   lift = PortMidiT . lift . lift
 
-{- | Exceptions that can occur while doing livecoding with PortMidi.
-
-There are two kinds of exceptions:
-
-* Internal PortMidi exceptions (see 'PMError')
-* When a device is not correctly specified by name and input/output configuration
--}
+-- | Exceptions that can occur while doing livecoding with PortMidi.
+--
+-- There are two kinds of exceptions:
+--
+-- * Internal PortMidi exceptions (see 'PMError')
+-- * When a device is not correctly specified by name and input/output configuration
 data EOLCPortMidiError
-  -- | An internal error occurred in the PortMidi library
-  = PMError PMError
-  -- | There is no device of that name
-  | NoSuchDevice
-  -- | There is a device of that name, but it doesn't support input
-  | NotAnInputDevice
-  -- | There is a device of that name, but it doesn't support output
-  | NotAnOutputDevice
-  -- | There are multiple devices of the same name
-  | MultipleDevices
+  = -- | An internal error occurred in the PortMidi library
+    PMError PMError
+  | -- | There is no device of that name
+    NoSuchDevice
+  | -- | There is a device of that name, but it doesn't support input
+    NotAnInputDevice
+  | -- | There is a device of that name, but it doesn't support output
+    NotAnOutputDevice
+  | -- | There are multiple devices of the same name
+    MultipleDevices
   deriving (Data, Generic, Show)
 
 instance Finite EOLCPortMidiError
 
 deriving instance Data PMError
+
 deriving instance Generic PMError
+
 instance Finite PMError
 
 -- ** Constructing values in 'PortMidiT'
@@ -107,72 +103,70 @@ liftHandlingState = hoistCell $ PortMidiT . lift
 
 -- ** Running values in 'PortMidiT'
 
-{- | Run a cell containing PortMidi effects.
-
-@'runPortMidiC' cell@ goes through the following steps:
-
-1. Initialize the MIDI system
-2. Run @cell@, until possibly an exception occurs
-3. Shut the MIDI system down
-4. Throw the exception in 'CellExcept'
--}
+-- | Run a cell containing PortMidi effects.
+--
+-- @'runPortMidiC' cell@ goes through the following steps:
+--
+-- 1. Initialize the MIDI system
+-- 2. Run @cell@, until possibly an exception occurs
+-- 3. Shut the MIDI system down
+-- 4. Throw the exception in 'CellExcept'
 runPortMidiC :: MonadIO m => Cell (PortMidiT m) a b -> CellExcept a b (HandlingStateT m) EOLCPortMidiError
 runPortMidiC cell = try $ proc a -> do
   _ <- liftCell $ handling portMidiHandle -< ()
   hoistCell unPortMidiT cell -< a
 
-{- | Repeatedly run a cell containing PortMidi effects.
-
-Effectively loops over 'runPortMidiC',
-and prints the exception after it occurred.
--}
+-- | Repeatedly run a cell containing PortMidi effects.
+--
+-- Effectively loops over 'runPortMidiC',
+-- and prints the exception after it occurred.
 loopPortMidiC :: MonadIO m => Cell (PortMidiT m) a b -> Cell (HandlingStateT m) a b
-loopPortMidiC cell = foreverC $ runCellExcept $ do
-  e <- runPortMidiC cell
-  once_ $ liftIO $ do
-    putStrLn "Encountered PortMidi exception:"
-    print e
-    threadDelay 1000
-  return e
+loopPortMidiC cell = foreverC $
+  runCellExcept $ do
+    e <- runPortMidiC cell
+    once_ $
+      liftIO $ do
+        putStrLn "Encountered PortMidi exception:"
+        print e
+        threadDelay 1000
+    return e
 
-{- | Execute the 'PortMidiT' effects'.
-
-This returns the first occurring exception.
-For details on how to automatically start and garbage collect handles,
-such as the PortMidi backend and devices,
-see "LiveCoding.HandlingState".
-
-You will rarely need this function.
-Look at 'runPortMidiC' and 'loopPortMidiC' instead.
--}
+-- | Execute the 'PortMidiT' effects'.
+--
+-- This returns the first occurring exception.
+-- For details on how to automatically start and garbage collect handles,
+-- such as the PortMidi backend and devices,
+-- see "LiveCoding.HandlingState".
+--
+-- You will rarely need this function.
+-- Look at 'runPortMidiC' and 'loopPortMidiC' instead.
 runPortMidiT :: PortMidiT m a -> HandlingStateT m (Either EOLCPortMidiError a)
-runPortMidiT PortMidiT { .. } = runExceptT unPortMidiT
+runPortMidiT PortMidiT {..} = runExceptT unPortMidiT
 
 -- * Input- and output streams
 
 -- | A stream associated to a PortMidi input device
-newtype PortMidiInputStream = PortMidiInputStream { unPortMidiInputStream :: PMStream }
+newtype PortMidiInputStream = PortMidiInputStream {unPortMidiInputStream :: PMStream}
 
 -- | A stream associated to a PortMidi output device
-newtype PortMidiOutputStream = PortMidiOutputStream { unPortMidiOutputStream :: PMStream }
+newtype PortMidiOutputStream = PortMidiOutputStream {unPortMidiOutputStream :: PMStream}
 
 -- | A marker to specify which kind of device to search
 data DeviceDirection = Input | Output
 
-{- | Look up a PortMidi device by its name and direction.
-
-You will rarely need this function.
-Consider 'readEventsC' and 'writeEventsC' instead.
--}
-lookupDeviceID
-  :: MonadIO m
-  => String
-  -> DeviceDirection
-  -> m (Either EOLCPortMidiError DeviceID)
+-- | Look up a PortMidi device by its name and direction.
+--
+-- You will rarely need this function.
+-- Consider 'readEventsC' and 'writeEventsC' instead.
+lookupDeviceID ::
+  MonadIO m =>
+  String ->
+  DeviceDirection ->
+  m (Either EOLCPortMidiError DeviceID)
 lookupDeviceID nameLookingFor inputOrOutput = do
   nDevices <- liftIO countDevices
   -- This is a bit of a race condition, but PortMidi has no better API
-  devices <- forM [0..nDevices-1] $ \deviceID -> do
+  devices <- forM [0 .. nDevices - 1] $ \deviceID -> do
     deviceInfo <- liftIO $ getDeviceInfo deviceID
     return (deviceInfo, deviceID)
   let allDevicesWithName = filter ((nameLookingFor ==) . name . fst) devices
@@ -187,74 +181,76 @@ lookupDeviceID nameLookingFor inputOrOutput = do
     _ -> Left MultipleDevices
 
 -- | A 'Handle' that opens a 'PortMidiInputStream' of the given device name.
-portMidiInputStreamHandle
-  :: MonadIO m
-  => String
-  -> Handle m (Either EOLCPortMidiError PortMidiInputStream)
-portMidiInputStreamHandle name = Handle
-  { create = runExceptT $ do
-      deviceID <- ExceptT $ lookupDeviceID name Input
-      fmap PortMidiInputStream $ withExceptT PMError $ ExceptT $ liftIO $ openInput deviceID
-  -- TODO I don't get the error from closing here.
-  -- Actually I really want ExceptT in the monad
-  , destroy = either (const $ return ()) $ liftIO . void . close . unPortMidiInputStream
-  }
+portMidiInputStreamHandle ::
+  MonadIO m =>
+  String ->
+  Handle m (Either EOLCPortMidiError PortMidiInputStream)
+portMidiInputStreamHandle name =
+  Handle
+    { create = runExceptT $ do
+        deviceID <- ExceptT $ lookupDeviceID name Input
+        fmap PortMidiInputStream $ withExceptT PMError $ ExceptT $ liftIO $ openInput deviceID,
+      -- TODO I don't get the error from closing here.
+      -- Actually I really want ExceptT in the monad
+      destroy = either (const $ return ()) $ liftIO . void . close . unPortMidiInputStream
+    }
 
 -- | Read all events from the 'PortMidiInputStream' that accumulated since the last tick.
-readEventsFrom
-  :: MonadIO m
-  => Cell (PortMidiT m) PortMidiInputStream [PMEvent]
+readEventsFrom ::
+  MonadIO m =>
+  Cell (PortMidiT m) PortMidiInputStream [PMEvent]
 readEventsFrom = arrM $ liftPMError . liftIO . readEvents . unPortMidiInputStream
 
-{- | Read all events from the input device of the given name.
-
-Automatically opens the device.
-
-This is basically a convenient combination of 'portMidiInputStreamHandle' and 'readEventsFrom'.
--}
-readEventsC
-  :: MonadIO m
-  => String -> Cell (PortMidiT m) arbitrary [PMEvent]
+-- | Read all events from the input device of the given name.
+--
+-- Automatically opens the device.
+--
+-- This is basically a convenient combination of 'portMidiInputStreamHandle' and 'readEventsFrom'.
+readEventsC ::
+  MonadIO m =>
+  String ->
+  Cell (PortMidiT m) arbitrary [PMEvent]
 readEventsC name = proc _ -> do
   pmStreamE <- liftHandlingState $ handling $ portMidiInputStreamHandle name -< ()
   pmStream <- hoistCell PortMidiT exceptC -< pmStreamE
   readEventsFrom -< pmStream
 
 -- | A 'Handle' that opens a 'PortMidiOutputStream' of the given device name.
-portMidiOutputStreamHandle
-  :: MonadIO m
-  => String
-  -> Handle m (Either EOLCPortMidiError PortMidiOutputStream)
-portMidiOutputStreamHandle name = Handle
-  { create = runExceptT $ do
-      deviceID <- ExceptT $ lookupDeviceID name Output
-      -- Choose same latency as supercollider, see https://github.com/supercollider/supercollider/blob/18c4aad363c49f29e866f884f5ac5bd35969d828/lang/LangPrimSource/SC_PortMIDI.cpp#L416
-      -- Thanks Miguel Negrão
-      fmap PortMidiOutputStream $ withExceptT PMError $ ExceptT $ liftIO $ openOutput deviceID 0
-  , destroy = either (const $ return ()) $ liftIO . void . close . unPortMidiOutputStream
-  }
+portMidiOutputStreamHandle ::
+  MonadIO m =>
+  String ->
+  Handle m (Either EOLCPortMidiError PortMidiOutputStream)
+portMidiOutputStreamHandle name =
+  Handle
+    { create = runExceptT $ do
+        deviceID <- ExceptT $ lookupDeviceID name Output
+        -- Choose same latency as supercollider, see https://github.com/supercollider/supercollider/blob/18c4aad363c49f29e866f884f5ac5bd35969d828/lang/LangPrimSource/SC_PortMIDI.cpp#L416
+        -- Thanks Miguel Negrão
+        fmap PortMidiOutputStream $ withExceptT PMError $ ExceptT $ liftIO $ openOutput deviceID 0,
+      destroy = either (const $ return ()) $ liftIO . void . close . unPortMidiOutputStream
+    }
 
 -- | Write all events to the 'PortMidiOutputStream'.
-writeEventsTo
-  :: MonadIO m
-  => Cell (PortMidiT m) (PortMidiOutputStream, [PMEvent]) ()
+writeEventsTo ::
+  MonadIO m =>
+  Cell (PortMidiT m) (PortMidiOutputStream, [PMEvent]) ()
 writeEventsTo = arrM writer
   where
-    writer (PortMidiOutputStream { .. }, events) = writeEvents unPortMidiOutputStream events
-      & liftIO
-      & liftPMError
-      & void
+    writer (PortMidiOutputStream {..}, events) =
+      writeEvents unPortMidiOutputStream events
+        & liftIO
+        & liftPMError
+        & void
 
-{- | Write all events to the output device of the given name.
-
-Automatically opens the device.
-
-This is basically a convenient combination of 'portMidiOutputStreamHandle' and 'writeEventsTo'.
--}
-writeEventsC
-  :: MonadIO m
-  => String
-  -> Cell (PortMidiT m) [PMEvent] ()
+-- | Write all events to the output device of the given name.
+--
+-- Automatically opens the device.
+--
+-- This is basically a convenient combination of 'portMidiOutputStreamHandle' and 'writeEventsTo'.
+writeEventsC ::
+  MonadIO m =>
+  String ->
+  Cell (PortMidiT m) [PMEvent] ()
 writeEventsC name = proc events -> do
   portMidiOutputStreamE <- liftHandlingState $ handling (portMidiOutputStreamHandle name) -< ()
   portMidiOutputStream <- hoistCell PortMidiT exceptC -< portMidiOutputStreamE
@@ -262,23 +258,24 @@ writeEventsC name = proc events -> do
 
 -- | All devices that the PortMidi backend has connected.
 data PortMidiDevices = PortMidiDevices
-  { inputDevices :: [DeviceInfo]
-  , outputDevices :: [DeviceInfo]
+  { inputDevices :: [DeviceInfo],
+    outputDevices :: [DeviceInfo]
   }
 
 -- | Retrieve all PortMidi devices.
 getPortMidiDevices :: IO PortMidiDevices
 getPortMidiDevices = do
   nDevices <- countDevices
-  devices <- mapM getDeviceInfo [0..nDevices-1]
-  return PortMidiDevices
-    { inputDevices = filter input devices
-    , outputDevices = filter output devices
-    }
+  devices <- mapM getDeviceInfo [0 .. nDevices - 1]
+  return
+    PortMidiDevices
+      { inputDevices = filter input devices,
+        outputDevices = filter output devices
+      }
 
 -- | Print input and output devices separately, one device per line.
 prettyPrintPortMidiDevices :: PortMidiDevices -> IO ()
-prettyPrintPortMidiDevices PortMidiDevices { .. } = do
+prettyPrintPortMidiDevices PortMidiDevices {..} = do
   putStrLn "\nPortMidi input devices:"
   putStrLn $ unlines $ printName <$> inputDevices
   putStrLn "\nPortMidi output devices:"

--- a/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi/Internal.hs
+++ b/essence-of-live-coding-PortMidi/src/LiveCoding/PortMidi/Internal.hs
@@ -1,22 +1,22 @@
 module LiveCoding.PortMidi.Internal where
 
 -- base
-import Control.Monad ( void )
+import Control.Monad (void)
 import Control.Monad.IO.Class
-
 -- PortMidi
-import Sound.PortMidi
 
 -- essence-of-live-coding
 import LiveCoding.Handle
+import Sound.PortMidi
 
 -- | A marker witnessing that PortMidi was initialized
 data PortMidiHandle = PortMidiHandle
 
 portMidiHandle :: MonadIO m => Handle m PortMidiHandle
-portMidiHandle = Handle
-  { create = do
-      liftIO initialize
-      return PortMidiHandle
-  , destroy = const $ liftIO $ void terminate
-  }
+portMidiHandle =
+  Handle
+    { create = do
+        liftIO initialize
+        return PortMidiHandle,
+      destroy = const $ liftIO $ void terminate
+    }

--- a/essence-of-live-coding-ghci-example/app/Main.hs
+++ b/essence-of-live-coding-ghci-example/app/Main.hs
@@ -2,15 +2,17 @@ module Main where
 
 -- base
 import Control.Concurrent (threadDelay)
-
 -- essence-of-live-coding
 import LiveCoding
 
 liveProgram :: LiveProgram (HandlingStateT IO)
-liveProgram = liveCell $ handling Handle
-  { create = threadDelay 10000 >> putStrLn "Creating"
-  , destroy = const $ putStrLn "Destroying"
-  }
+liveProgram =
+  liveCell $
+    handling
+      Handle
+        { create = threadDelay 10000 >> putStrLn "Creating",
+          destroy = const $ putStrLn "Destroying"
+        }
 
 main :: IO ()
 main = liveMain liveProgram

--- a/essence-of-live-coding-gloss-example/Setup.hs
+++ b/essence-of-live-coding-gloss-example/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/essence-of-live-coding-gloss/Setup.hs
+++ b/essence-of-live-coding-gloss/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/essence-of-live-coding-gloss/src/LiveCoding/Gloss.hs
+++ b/essence-of-live-coding-gloss/src/LiveCoding/Gloss.hs
@@ -1,128 +1,132 @@
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE Arrows #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 
 module LiveCoding.Gloss
-  ( module X
-  , module LiveCoding.Gloss
-  ) where
+  ( module X,
+    module LiveCoding.Gloss,
+  )
+where
 
 -- base
-import Control.Concurrent
-import Control.Monad (when)
-import Data.IORef
-import System.Exit (exitSuccess)
 
 -- transformers
 import Control.Arrow (returnA)
-import Control.Monad.Trans.Writer
+import Control.Concurrent
+import Control.Monad (when)
 import Control.Monad.Trans.State.Strict (StateT)
-
+import Control.Monad.Trans.Writer
+import Data.IORef
 -- gloss
 import Graphics.Gloss as X
 import Graphics.Gloss.Interface.IO.Game as X
-
 -- essence-of-live-coding
 import LiveCoding
-
 -- essence-of-live-coding-gloss
 import LiveCoding.Gloss.Debugger as X
 import LiveCoding.Gloss.PictureM as X
+import System.Exit (exitSuccess)
 
 -- | In a 'Handle', store a separate thread where the gloss main loop is executed,
 --   and several concurrent variables to communicate with it.
 data GlossHandle = GlossHandle
-  { glossThread :: ThreadId
-  , glossVars   :: GlossVars
+  { glossThread :: ThreadId,
+    glossVars :: GlossVars
   }
 
 -- | The concurrent variables needed to communicate with the gloss thread.
 data GlossVars = GlossVars
-  { glossEventsRef :: IORef [Event]
-    -- ^ Stores all 'Event's that arrived since the last tick
-  , glossPicRef    :: IORef Picture
-    -- ^ Stores the next 'Picture' to be painted
-  , glossDTimeVar  :: MVar Float
-    -- ^ Stores the time passed since the last tick
-  , glossExitRef   :: IORef Bool
-    -- ^ Write 'True' here to stop the gloss thread
+  { -- | Stores all 'Event's that arrived since the last tick
+    glossEventsRef :: IORef [Event],
+    -- | Stores the next 'Picture' to be painted
+    glossPicRef :: IORef Picture,
+    -- | Stores the time passed since the last tick
+    glossDTimeVar :: MVar Float,
+    -- | Write 'True' here to stop the gloss thread
+    glossExitRef :: IORef Bool
   }
 
 -- | Collect all settings that the @gloss@ backend requires.
 --   Taken from @rhine-gloss@.
 data GlossSettings = GlossSettings
-  { displaySetting  :: Display      -- ^ Display mode (e.g. 'InWindow' or 'FullScreen').
-  , backgroundColor :: Color        -- ^ Background color.
-  , stepsPerSecond  :: Int          -- ^ Number of simulation steps per second of real time.
-  , debugEvents     :: Bool         -- ^ Print all incoming events to the console.
+  { -- | Display mode (e.g. 'InWindow' or 'FullScreen').
+    displaySetting :: Display,
+    -- | Background color.
+    backgroundColor :: Color,
+    -- | Number of simulation steps per second of real time.
+    stepsPerSecond :: Int,
+    -- | Print all incoming events to the console.
+    debugEvents :: Bool
   }
 
 defaultSettings :: GlossSettings
-defaultSettings = GlossSettings
-  { displaySetting  = InWindow "Essence of live coding" (600, 800) (20, 20)
-  , backgroundColor = black
-  , stepsPerSecond  = 30
-  , debugEvents     = False
-  }
+defaultSettings =
+  GlossSettings
+    { displaySetting = InWindow "Essence of live coding" (600, 800) (20, 20),
+      backgroundColor = black,
+      stepsPerSecond = 30,
+      debugEvents = False
+    }
 
 -- | Will create a handle for communication with the gloss thread,
 --   and start gloss.
 glossHandle :: GlossSettings -> Handle IO GlossHandle
-glossHandle GlossSettings { .. } = Handle
-  { create = do
-      glossEventsRef <- newIORef []
-      glossDTimeVar <- newEmptyMVar
-      glossPicRef <- newIORef blank
-      glossExitRef <- newIORef False
-      let glossVars = GlossVars { .. }
-      glossThread <- forkIO
-        $ playIO displaySetting backgroundColor stepsPerSecond glossVars getPicture (handleEvent debugEvents) stepGloss
-      return GlossHandle { .. }
-  , destroy = \GlossHandle { glossVars = GlossVars { .. }, .. } -> writeIORef glossExitRef True
-  }
+glossHandle GlossSettings {..} =
+  Handle
+    { create = do
+        glossEventsRef <- newIORef []
+        glossDTimeVar <- newEmptyMVar
+        glossPicRef <- newIORef blank
+        glossExitRef <- newIORef False
+        let glossVars = GlossVars {..}
+        glossThread <-
+          forkIO $
+            playIO displaySetting backgroundColor stepsPerSecond glossVars getPicture (handleEvent debugEvents) stepGloss
+        return GlossHandle {..},
+      destroy = \GlossHandle {glossVars = GlossVars {..}, ..} -> writeIORef glossExitRef True
+    }
 
 getPicture :: GlossVars -> IO Picture
-getPicture GlossVars { .. } = readIORef glossPicRef
+getPicture GlossVars {..} = readIORef glossPicRef
 
 handleEvent :: Bool -> Event -> GlossVars -> IO GlossVars
-handleEvent debugEvents event vars@GlossVars { .. } = do
+handleEvent debugEvents event vars@GlossVars {..} = do
   when debugEvents $ print event
   modifyIORef glossEventsRef (event :)
   return vars
 
 stepGloss :: Float -> GlossVars -> IO GlossVars
-stepGloss dTime vars@GlossVars { .. } = do
+stepGloss dTime vars@GlossVars {..} = do
   putMVar glossDTimeVar dTime
   exitNow <- readIORef glossExitRef
   when exitNow exitSuccess
   return vars
 
-{- | Given a cell in the gloss monad 'PictureM',
-start the gloss backend and connect the cell to it.
-
-This introduces 'Handle's containing the gloss background thread,
-which need to be taken care of by calling 'runHandlingState'
-or a similar function.
-
-The resulting cell never blocks,
-but returns 'Nothing' if there currently is no gloss tick.
--}
-glossWrapC
-  :: GlossSettings
-  -> Cell PictureM a b
-  -> Cell (HandlingStateT IO) a (Maybe b)
+-- | Given a cell in the gloss monad 'PictureM',
+-- start the gloss backend and connect the cell to it.
+--
+-- This introduces 'Handle's containing the gloss background thread,
+-- which need to be taken care of by calling 'runHandlingState'
+-- or a similar function.
+--
+-- The resulting cell never blocks,
+-- but returns 'Nothing' if there currently is no gloss tick.
+glossWrapC ::
+  GlossSettings ->
+  Cell PictureM a b ->
+  Cell (HandlingStateT IO) a (Maybe b)
 glossWrapC glossSettings cell = proc a -> do
-  GlossHandle { .. } <- handling $ glossHandle glossSettings -< ()
+  GlossHandle {..} <- handling $ glossHandle glossSettings -< ()
   liftCell pump -< (glossVars, a)
   where
-    pump = proc (GlossVars { .. }, a) -> do
-      timeMaybe <- arrM tryTakeMVar                        -< glossDTimeVar
+    pump = proc (GlossVars {..}, a) -> do
+      timeMaybe <- arrM tryTakeMVar -< glossDTimeVar
       case timeMaybe of
         Just _ -> do
-          events <- arrM $ flip atomicModifyIORef ([], ) -< glossEventsRef
-          (picture, b) <- runPictureT cell               -< (events, a)
-          arrM (uncurry writeIORef)                      -< (glossPicRef, picture)
-          returnA                                        -< Just b
+          events <- arrM $ flip atomicModifyIORef ([],) -< glossEventsRef
+          (picture, b) <- runPictureT cell -< (events, a)
+          arrM (uncurry writeIORef) -< (glossPicRef, picture)
+          returnA -< Just b
         Nothing -> do
-          arrM threadDelay       -< 1000 -- Prevent too much CPU load
-          returnA                -< Nothing
+          arrM threadDelay -< 1000 -- Prevent too much CPU load
+          returnA -< Nothing

--- a/essence-of-live-coding-gloss/src/LiveCoding/Gloss/Debugger.hs
+++ b/essence-of-live-coding-gloss/src/LiveCoding/Gloss/Debugger.hs
@@ -1,24 +1,21 @@
 {-# LANGUAGE Arrows #-}
+
 module LiveCoding.Gloss.Debugger where
 
 -- base
 import Control.Arrow
-import Data.Data
-
 -- transformers
-import Control.Monad.Trans.Writer.Strict
+
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.State.Strict
-
+import Control.Monad.Trans.Writer.Strict
+import Data.Data
 -- syb
 import Data.Generics.Text
-
 -- gloss
 import Graphics.Gloss
-
 -- essence-of-live-coding
 import LiveCoding
-
 -- essence-of-live-coding-gloss
 import LiveCoding.Gloss.PictureM
 
@@ -32,9 +29,8 @@ every :: Data s => Integer -> Cell (StateT s PictureM) () (Maybe Picture)
 every maxN = proc () -> do
   n <- sumC -< 1
   if n `mod` maxN == 0
-  then do
-    s <- getC -< ()
-    let pic = statePicture s
-    returnA -< Just pic
-  else
-    returnA  -< Nothing
+    then do
+      s <- getC -< ()
+      let pic = statePicture s
+      returnA -< Just pic
+    else returnA -< Nothing

--- a/essence-of-live-coding-gloss/src/LiveCoding/Gloss/PictureM.hs
+++ b/essence-of-live-coding-gloss/src/LiveCoding/Gloss/PictureM.hs
@@ -1,38 +1,36 @@
 module LiveCoding.Gloss.PictureM
-  ( module LiveCoding.Gloss.PictureM
-  , module X
-  ) where
+  ( module LiveCoding.Gloss.PictureM,
+    module X,
+  )
+where
 
 -- transformers
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Reader as X
 import Control.Monad.Trans.Writer.Strict
-
 -- gloss
 import Graphics.Gloss
 import Graphics.Gloss.Interface.IO.Game
-
 -- essence-of-live-coding
 import LiveCoding
 
-{- | The monad transformer that captures the effects of gloss,
-which are reading events and writing pictures.
-
-You can call these effects for example by...
-
-* ...using 'ask' to read the events that occurred,
-* ...composing a cell with 'addPicture' to paint a picture.
--}
+-- | The monad transformer that captures the effects of gloss,
+-- which are reading events and writing pictures.
+--
+-- You can call these effects for example by...
+--
+-- * ...using 'ask' to read the events that occurred,
+-- * ...composing a cell with 'addPicture' to paint a picture.
 type PictureT m = ReaderT [Event] (WriterT Picture m)
 
 -- | 'PictureT' specialised to the 'IO' monad.
 type PictureM = PictureT IO
 
 -- | Run the effects of the gloss monad stack by explicitly passing events and pictures.
-runPictureT
-  :: Monad m
-  => Cell (PictureT m) a b
-  -> Cell m ([Event], a) (Picture, b)
+runPictureT ::
+  Monad m =>
+  Cell (PictureT m) a b ->
+  Cell m ([Event], a) (Picture, b)
 runPictureT = runWriterC . runReaderC'
 
 addPicture :: Monad m => Cell (PictureT m) Picture ()

--- a/essence-of-live-coding-pulse-example/app/Main.hs
+++ b/essence-of-live-coding-pulse-example/app/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE TupleSections #-}
+
 module Main where
 
 -- base
@@ -7,41 +8,37 @@ import Control.Arrow as X
 import Control.Concurrent
 import Control.Monad (void)
 import Control.Monad.Fix
-import qualified Data.List.NonEmpty as NonEmpty
-import Data.List.NonEmpty (NonEmpty)
-
-import Prelude hiding ((!))
-
 -- transformers
 import Control.Monad.Trans.Reader
-
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
 -- vector
-import qualified Data.Vector as Vector
-import Data.Vector ((!))
 
+import Data.Vector ((!))
+import qualified Data.Vector as Vector
 -- pulse-simple
-import Sound.Pulse.Simple
 
 -- essence-of-live-coding
 import LiveCoding
-
 -- essence-of-live-coding-pulse
 import LiveCoding.Pulse
+import Sound.Pulse.Simple
+import Prelude hiding ((!))
 
 fastSine :: (Data a, Floating a, MonadFix m) => Cell (ReaderT a m) () a
 fastSine = proc _ -> do
   t <- constM ask -< ()
-  rec
-    let acc = - (2 * pi / t) ^ 2 * pos
-    vel <- sumC' <<< delay 0 -< acc
-    pos <- arr (+ 1) <<< sumC' -< vel
+  rec let acc = -(2 * pi / t) ^ 2 * pos
+      vel <- sumC' <<< delay 0 -< acc
+      pos <- arr (+ 1) <<< sumC' -< vel
   returnA -< pos
 
 sumC' :: (Monad m, Data a, Num a) => Cell m a a
-sumC' = Cell
-  { cellState = 0
-  , cellStep  = \accum a -> let accum' = accum + a in return (accum', accum')
-  }
+sumC' =
+  Cell
+    { cellState = 0,
+      cellStep = \accum a -> let accum' = accum + a in return (accum', accum')
+    }
 
 cellA :: MonadFix m => Cell m () Float
 cellA = runReaderC (44100 / 440) fastSine
@@ -62,9 +59,11 @@ frequencies :: Monad m => Cell m () Float
 frequencies = foreverC $ runCellExcept $ sequence $ (short . f) <$> [C, E, G]
 
 cycleThrough :: Monad m => NonEmpty a -> Int -> Cell m () a
-cycleThrough bs cycleLength = let vector = Vector.fromList (NonEmpty.toList bs) in proc _ -> do
-  n <- modSum (cycleLength * length bs) -< 1
-  returnA -< vector ! (n `div` cycleLength)
+cycleThrough bs cycleLength =
+  let vector = Vector.fromList (NonEmpty.toList bs)
+   in proc _ -> do
+        n <- modSum (cycleLength * length bs) -< 1
+        returnA -< vector ! (n `div` cycleLength)
 
 frequencies' :: Monad m => Cell m () Float
 frequencies' = cycleThrough (NonEmpty.fromList $ [f D, f G, o $ f Bb]) 8000

--- a/essence-of-live-coding-pulse/Setup.hs
+++ b/essence-of-live-coding-pulse/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/essence-of-live-coding-quickcheck/Setup.hs
+++ b/essence-of-live-coding-quickcheck/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/essence-of-live-coding-speedtest-yampa/app/SpeedTest.hs
+++ b/essence-of-live-coding-speedtest-yampa/app/SpeedTest.hs
@@ -1,20 +1,17 @@
--- | For a simple speedtest, run e.g. the following command in Linux:
---   stack build && time stack exec SpeedTest
-
 {-# LANGUAGE Arrows #-}
 
+-- | For a simple speedtest, run e.g. the following command in Linux:
+--   stack build && time stack exec SpeedTest
 module Main (main) where
 
 -- base
 import Control.Arrow
 import Control.Monad (void)
-import Data.Data
-import Data.Semigroup
-
 -- transformers
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (runExceptT)
-
+import Data.Data
+import Data.Semigroup
 -- essence-of-live-coding
 import LiveCoding
 
@@ -23,14 +20,14 @@ accum w0 = feedback w0 $ arr $ \(w, state) -> (state, w <> state)
 
 mainCell = proc _ -> do
   x <- sine 1 -< ()
-  s <- sumC   -< x
+  s <- sumC -< x
   m <- accum (Max 0) -< Max x
   m' <- accum (Min 0) -< Min x
-  c <- sumC   -< (1 :: Int)
+  c <- sumC -< (1 :: Int)
   if c > 1000 * 1000
     then do
       arrM (lift . print) -< (s, getMax m, getMin m')
-      throwC  -< ()
+      throwC -< ()
     else returnA -< ()
 
 main :: IO ()

--- a/essence-of-live-coding-speedtest-yampa/app/SpeedTestYampa.hs
+++ b/essence-of-live-coding-speedtest-yampa/app/SpeedTestYampa.hs
@@ -4,23 +4,20 @@ module Main (main) where
 
 -- base
 import Data.Maybe (isJust)
-
 -- yampa
 import FRP.Yampa
 
 sine k = proc () -> do
-  rec
-    let acc = - k * pos
-    vel <- integral -< acc
-    pos <- (+1) ^<< integral -< vel
+  rec let acc = -k * pos
+      vel <- integral -< acc
+      pos <- (+ 1) ^<< integral -< vel
   returnA -< pos
 
 oscillator :: Double -> Double -> SF a Double
 oscillator amp period = proc _ -> do
-  rec
-    let acc = - (2.0*pi/period)^(2 :: Int) * p
-    v <- integral -< acc
-    p <- (amp +) ^<< integral -< v
+  rec let acc = -(2.0 * pi / period) ^ (2 :: Int) * p
+      v <- integral -< acc
+      p <- (amp +) ^<< integral -< v
   returnA -< p
 
 timestep :: Double
@@ -37,12 +34,13 @@ mainSF = proc _ -> do
     then returnA -< Left s
     else returnA -< Right x
 
-main = reactimate
-  (return ())
-  (const $ return (1/timestep, Just ()))
-  --(const $ \b -> if isJust b then print b >> return True else return False)
-  helper
-  mainSF
+main =
+  reactimate
+    (return ())
+    (const $ return (1 / timestep, Just ()))
+    -- (const $ \b -> if isJust b then print b >> return True else return False)
+    helper
+    mainSF
   where
     helper _ (Left s) = print s >> return True
     helper _ (Right x) = return False

--- a/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
+++ b/essence-of-live-coding-vivid/src/LiveCoding/Vivid.hs
@@ -1,48 +1,45 @@
-{- | Support for [@vivid@](https://hackage.haskell.org/package/vivid),
-a Haskell library for [SuperCollider](https://supercollider.github.io/).
-
-With this module, you can create cells corresponding to synthesizers.
-
-The synthesizers automatically start and stop on reload.
--}
-
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
+
+-- | Support for [@vivid@](https://hackage.haskell.org/package/vivid),
+-- a Haskell library for [SuperCollider](https://supercollider.github.io/).
+--
+-- With this module, you can create cells corresponding to synthesizers.
+--
+-- The synthesizers automatically start and stop on reload.
 module LiveCoding.Vivid where
 
 -- base
 import Data.Foldable (traverse_)
 import GHC.TypeLits (KnownSymbol)
-
 -- vivid
-import Vivid
 
 -- essence-of-live-coding
-import LiveCoding.Handle
+
 import LiveCoding
+import LiveCoding.Handle
+import Vivid
 
-{- | Whether a synthesizer should currently be running or not.
-
-Typically, you will either statically supply the value and change it in the code to start and stop the synth,
-or you can connect another cell to it.
--}
+-- | Whether a synthesizer should currently be running or not.
+--
+-- Typically, you will either statically supply the value and change it in the code to start and stop the synth,
+-- or you can connect another cell to it.
 data SynthState
   = Started
   | Stopped
   deriving (Eq)
 
-{- | A 'ParametrisedHandle' corresponding to one @vivid@/@SuperCollider@ synthesizer.
-
-Usually, you will want to use 'liveSynth' instead, it is easier to handle.
--}
-vividHandleParametrised
-  :: (VividAction m, Eq params, VarList params, Subset (InnerVars params) args, Elem "gate" args)
-  => ParametrisedHandle (params, SynthDef args, SynthState) m (Maybe (Synth args))
-vividHandleParametrised = ParametrisedHandle { .. }
+-- | A 'ParametrisedHandle' corresponding to one @vivid@/@SuperCollider@ synthesizer.
+--
+-- Usually, you will want to use 'liveSynth' instead, it is easier to handle.
+vividHandleParametrised ::
+  (VividAction m, Eq params, VarList params, Subset (InnerVars params) args, Elem "gate" args) =>
+  ParametrisedHandle (params, SynthDef args, SynthState) m (Maybe (Synth args))
+vividHandleParametrised = ParametrisedHandle {..}
   where
     createParametrised (params, synthDef, Started) = Just <$> synth synthDef params
     createParametrised (params, synthDef, Stopped) = defineSD synthDef >> pure Nothing
@@ -59,39 +56,44 @@ vividHandleParametrised = ParametrisedHandle { .. }
     changeParametrised old new synth = defaultChange createParametrised destroyParametrised old new synth
 
 deriving instance Data SynthState
+
 deriving instance KnownSymbol a => Data (I a)
 
-{- | Create a synthesizer.
-
-When you add 'liveSynth' to your live program,
-it will be started upon reload immediately.
-
-Feed the definition of the synthesizer and its current intended state to this cell.
-The input has the form @(params, sdbody, synthState)@.
-
-* A change in @params@ will reload the synthesizer quickly,
-  unless the types of the parameters change.
-* A change in the @sdbody :: 'SDBody' ...@ or the _types_ of the @params@ will 'release' the synthesizer and start a new one.
-* The input @synthState :: 'SynthState'@ represent whether the synthesizer should currently be running or not.
-  Changes in it quickly start or stop it.
-  * When it is started, @'Just' synth@ is returned, where @synth@ represents the running synthesizer.
-  * When it is stopped, 'Nothing' is returned.
-
-You have to use 'envGate' in your @sdbody@,
-or another way of gating your output signals
-in order to ensure release of the synths without clipping.
-
-For an example, have a look at the source code of 'sine'.
--}
-liveSynth
-  :: ( VividAction m
-     , Eq params, Typeable params, VarList params
-     , Typeable (InnerVars params), Subset (InnerVars params) (InnerVars params)
-     , Elem "gate" (InnerVars params), Data params
-     )
-  => Cell (HandlingStateT m)
-       (params, SDBody' (InnerVars params) [Signal], SynthState)
-       (Maybe (Synth (InnerVars params)))
+-- | Create a synthesizer.
+--
+-- When you add 'liveSynth' to your live program,
+-- it will be started upon reload immediately.
+--
+-- Feed the definition of the synthesizer and its current intended state to this cell.
+-- The input has the form @(params, sdbody, synthState)@.
+--
+-- * A change in @params@ will reload the synthesizer quickly,
+--  unless the types of the parameters change.
+-- * A change in the @sdbody :: 'SDBody' ...@ or the _types_ of the @params@ will 'release' the synthesizer and start a new one.
+-- * The input @synthState :: 'SynthState'@ represent whether the synthesizer should currently be running or not.
+--  Changes in it quickly start or stop it.
+--  * When it is started, @'Just' synth@ is returned, where @synth@ represents the running synthesizer.
+--  * When it is stopped, 'Nothing' is returned.
+--
+-- You have to use 'envGate' in your @sdbody@,
+-- or another way of gating your output signals
+-- in order to ensure release of the synths without clipping.
+--
+-- For an example, have a look at the source code of 'sine'.
+liveSynth ::
+  ( VividAction m,
+    Eq params,
+    Typeable params,
+    VarList params,
+    Typeable (InnerVars params),
+    Subset (InnerVars params) (InnerVars params),
+    Elem "gate" (InnerVars params),
+    Data params
+  ) =>
+  Cell
+    (HandlingStateT m)
+    (params, SDBody' (InnerVars params) [Signal], SynthState)
+    (Maybe (Synth (InnerVars params)))
 liveSynth = proc (params, sdbody, synthstate) -> do
   paramsFirstValue <- holdFirst -< params
   handlingParametrised vividHandleParametrised -< (params, sd paramsFirstValue sdbody, synthstate)
@@ -99,12 +101,13 @@ liveSynth = proc (params, sdbody, synthstate) -> do
 -- | Example sine synthesizer that creates a sine wave at the given input frequency.
 sine :: (VividAction m) => Cell (HandlingStateT m) Float ()
 sine = proc frequency -> do
-  liveSynth -<
-    (
-      ( 1 :: I "gate"
-      , 2 :: I "fadeSecs"
-      , I frequency :: I "freq"
+  liveSynth
+    -<
+      ( ( 1 :: I "gate",
+          2 :: I "fadeSecs",
+          I frequency :: I "freq"
+        ),
+        out (0 :: Int) [envGate ~* sinOsc (freq_ (V :: V "freq"))],
+        Started
       )
-    , out (0 :: Int) [envGate ~* sinOsc (freq_ (V :: V "freq"))]
-    , Started)
   returnA -< ()

--- a/essence-of-live-coding-warp/Setup.hs
+++ b/essence-of-live-coding-warp/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/essence-of-live-coding-warp/src/LiveCoding/Warp.hs
+++ b/essence-of-live-coding-warp/src/LiveCoding/Warp.hs
@@ -1,100 +1,97 @@
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
-{- | Live coding backend to the [@warp@](https://hackage.haskell.org/package/warp) server.
 
-If you write a cell that consumes 'Request's and produces 'Response's,
-you can use the functions here that run this cell as a @warp@ application.
--}
+-- | Live coding backend to the [@warp@](https://hackage.haskell.org/package/warp) server.
+--
+-- If you write a cell that consumes 'Request's and produces 'Response's,
+-- you can use the functions here that run this cell as a @warp@ application.
 module LiveCoding.Warp
-  ( runWarpC
-  , runWarpC_
-  , module X
-  ) where
+  ( runWarpC,
+    runWarpC_,
+    module X,
+  )
+where
 
 -- base
 import Control.Concurrent
 import Control.Monad.IO.Class
-
 -- http-types
-import Network.HTTP.Types as X
 
 -- wai
-import Network.Wai as X
 
 -- warp
-import Network.Wai.Handler.Warp
 
 -- essence-of-live-coding
 import LiveCoding
+import Network.HTTP.Types as X
+import Network.Wai as X
+import Network.Wai.Handler.Warp
 
 data WaiHandle = WaiHandle
-  { requestVar  :: MVar Request
-  , responseVar :: MVar Response
-  , appThread   :: ThreadId
+  { requestVar :: MVar Request,
+    responseVar :: MVar Response,
+    appThread :: ThreadId
   }
 
 -- I believe there is a bug here where a request is missed if the app blocks because the requestVar isn't emptied, or the response not filled.
 
 waiHandle :: Port -> Handle IO WaiHandle
-waiHandle port = Handle
-  { create = do
-      requestVar <- newEmptyMVar
-      responseVar <- newEmptyMVar
-      let app request respond = do
+waiHandle port =
+  Handle
+    { create = do
+        requestVar <- newEmptyMVar
+        responseVar <- newEmptyMVar
+        let app request respond = do
               putMVar requestVar request
               response <- takeMVar responseVar
               respond response
-      appThread <- forkIO $ run port app
-      return WaiHandle { .. }
-  , destroy = \WaiHandle { .. } -> killThread appThread
-  }
+        appThread <- forkIO $ run port app
+        return WaiHandle {..},
+      destroy = \WaiHandle {..} -> killThread appThread
+    }
 
-{- | Run a 'Cell' as a WARP application.
-
-1. Starts a WARP application on the given port in a background thread
-2. Waits until the next request arrives, outputting 'Nothing' in the meantime
-3. Supplies the cell with the input and the current request
-4. Serve the response and return the output
--}
-
-runWarpC
-  :: Port
-  -> Cell IO (a, Request) (b, Response)
-  -> Cell (HandlingStateT IO) a (Maybe b)
+-- | Run a 'Cell' as a WARP application.
+--
+-- 1. Starts a WARP application on the given port in a background thread
+-- 2. Waits until the next request arrives, outputting 'Nothing' in the meantime
+-- 3. Supplies the cell with the input and the current request
+-- 4. Serve the response and return the output
+runWarpC ::
+  Port ->
+  Cell IO (a, Request) (b, Response) ->
+  Cell (HandlingStateT IO) a (Maybe b)
 runWarpC port cell = proc a -> do
-  WaiHandle { .. } <- handling $ waiHandle port -< ()
-  requestMaybe <- arrM $ liftIO . tryTakeMVar   -< requestVar
+  WaiHandle {..} <- handling $ waiHandle port -< ()
+  requestMaybe <- arrM $ liftIO . tryTakeMVar -< requestVar
   case requestMaybe of
     Just request -> do
-      (b, response) <- liftCell cell  -< (a, request)
+      (b, response) <- liftCell cell -< (a, request)
       arrM $ liftIO . uncurry putMVar -< (responseVar, response)
-      returnA                         -< Just b
+      returnA -< Just b
     Nothing -> do
-      arrM $ liftIO . threadDelay     -< 1000 -- Prevent too much CPU load
-      returnA                         -< Nothing
+      arrM $ liftIO . threadDelay -< 1000 -- Prevent too much CPU load
+      returnA -< Nothing
 
 -- | A simple live-codable web application is a cell that consumes HTTP 'Request's and emits 'Response's for each.
 type LiveWebApp = Cell IO Request Response
 
-{- | Like 'runWarpC', but don't consume additional input or produce additional output.
-
-Suitable for a main program, for example like this:
-
-@
-mainCell :: Cell IO Request Response
-mainCell = undefined
-
-liveProgram :: LiveProgram (HandlingStateT IO)
-liveProgram = liveCell mainCell
-
-main :: IO ()
-main = liveMain liveProgram
-@
--}
-
-runWarpC_
-  :: Port
-  -> LiveWebApp
-  -> Cell (HandlingStateT IO) () ()
-runWarpC_ port cell = runWarpC port (arr snd >>> cell >>> arr ((), )) >>> arr (const ())
+-- | Like 'runWarpC', but don't consume additional input or produce additional output.
+--
+-- Suitable for a main program, for example like this:
+--
+-- @
+-- mainCell :: Cell IO Request Response
+-- mainCell = undefined
+--
+-- liveProgram :: LiveProgram (HandlingStateT IO)
+-- liveProgram = liveCell mainCell
+--
+-- main :: IO ()
+-- main = liveMain liveProgram
+-- @
+runWarpC_ ::
+  Port ->
+  LiveWebApp ->
+  Cell (HandlingStateT IO) () ()
+runWarpC_ port cell = runWarpC port (arr snd >>> cell >>> arr ((),)) >>> arr (const ())

--- a/essence-of-live-coding-warp/test/Main.hs
+++ b/essence-of-live-coding-warp/test/Main.hs
@@ -2,19 +2,16 @@
 
 -- base
 import Control.Monad (unless)
-import System.Exit
-
 -- bytestring
 import Data.ByteString.Lazy
-
 -- http-client
-import Network.HTTP.Client hiding (Response)
 
 -- essence-of-live-coding
 import LiveCoding
-
 -- essence-of-live-coding-warp
 import LiveCoding.Warp
+import Network.HTTP.Client hiding (Response)
+import System.Exit
 
 response :: ByteString -> Response
 response = responseLBS status200 [("Content-Type", "text/plain")]

--- a/essence-of-live-coding/Setup.hs
+++ b/essence-of-live-coding/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/essence-of-live-coding/app/TestExceptions.hs
+++ b/essence-of-live-coding/app/TestExceptions.hs
@@ -2,15 +2,13 @@
 
 -- base
 import Control.Arrow
-
 -- transformers
 import Control.Monad.Trans.Class
-
 -- essence-of-live-coding
 import LiveCoding
 
-liveProgram = liveCell
-  $ safely $ do
+liveProgram = liveCell $
+  safely $ do
     try $ throwingCell
     safe $ arr (const (3 :: Integer)) >>> sumC >>> arr (const ())
 

--- a/essence-of-live-coding/app/TestNonBlocking.hs
+++ b/essence-of-live-coding/app/TestNonBlocking.hs
@@ -1,17 +1,16 @@
 {-# LANGUAGE Arrows #-}
 
 module Main
-  ( module Main
-  , module X
-  ) where
+  ( module Main,
+    module X,
+  )
+where
 
 -- base
 import Control.Arrow
 import Control.Concurrent
-
 -- transformers
 import Control.Monad.Trans.Class
-
 -- essence-of-live-coding
 import LiveCoding
 import LiveCoding.GHCi as X
@@ -36,11 +35,11 @@ mainCell :: Cell (HandlingStateT IO) () ()
 mainCell =
   let keyboard = nonBlocking False $ constM getLine -- Only poll, never abort
       mySlowId = nonBlocking True slowId -- Abort and restart when new data arrives
-  in proc _ -> do
-    n <- count                             -< ()
-    lineMaybe <- keyboard                  -< Just ()
-    let nString = show n <$ lineMaybe
-    resampleMaybe (arrM $ lift . putStrLn) -< ("Calculating " ++) <$> nString
-    resultMaybe <- mySlowId                -< nString
-    resampleMaybe (arrM $ lift . putStrLn) -< ("Calculated "  ++) <$> resultMaybe
-    arrM $ lift .threadDelay               -< 1000 -- Don't hog CPU
+   in proc _ -> do
+        n <- count -< ()
+        lineMaybe <- keyboard -< Just ()
+        let nString = show n <$ lineMaybe
+        resampleMaybe (arrM $ lift . putStrLn) -< ("Calculating " ++) <$> nString
+        resultMaybe <- mySlowId -< nString
+        resampleMaybe (arrM $ lift . putStrLn) -< ("Calculated " ++) <$> resultMaybe
+        arrM $ lift . threadDelay -< 1000 -- Don't hog CPU

--- a/essence-of-live-coding/src/LiveCoding.hs
+++ b/essence-of-live-coding/src/LiveCoding.hs
@@ -1,11 +1,8 @@
-module LiveCoding
-  (module X)
-  where
+module LiveCoding (module X) where
 
 -- base
 import Control.Arrow as X hiding (app)
 import Data.Data as X
-
 -- essence-of-live-coding
 import LiveCoding.Bind as X
 import LiveCoding.Cell as X
@@ -24,22 +21,22 @@ import LiveCoding.Exceptions as X
 import LiveCoding.Exceptions.Finite as X
 import LiveCoding.Forever as X
 import LiveCoding.Handle as X
-import LiveCoding.HandlingState as X
-    ( HandlingStateT,
-      HandlingState(..),
-      Handling(..),
-      isRegistered,
-      runHandlingStateT,
-      runHandlingStateC,
-      runHandlingState,
-    )
 import LiveCoding.Handle.Examples as X
+import LiveCoding.HandlingState as X
+  ( Handling (..),
+    HandlingState (..),
+    HandlingStateT,
+    isRegistered,
+    runHandlingState,
+    runHandlingStateC,
+    runHandlingStateT,
+  )
 import LiveCoding.LiveProgram as X
 import LiveCoding.LiveProgram.HotCodeSwap as X
 import LiveCoding.LiveProgram.Monad.Trans as X
 import LiveCoding.Migrate as X
 import LiveCoding.Migrate.Debugger as X
 import LiveCoding.Migrate.Migration as X
-import LiveCoding.Migrate.NoMigration as X hiding (delay, changes)
+import LiveCoding.Migrate.NoMigration as X hiding (changes, delay)
 import LiveCoding.RuntimeIO as X hiding (update)
 import LiveCoding.RuntimeIO.Launch as X hiding (foreground)

--- a/essence-of-live-coding/src/LiveCoding/Cell/HotCodeSwap.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/HotCodeSwap.hs
@@ -4,14 +4,14 @@ module LiveCoding.Cell.HotCodeSwap where
 import LiveCoding.Cell
 import LiveCoding.Migrate
 
-hotCodeSwapCell
-  :: Cell m a b
-  -> Cell m a b
-  -> Cell m a b
+hotCodeSwapCell ::
+  Cell m a b ->
+  Cell m a b ->
+  Cell m a b
 hotCodeSwapCell
   (Cell newState newStep)
-  (Cell oldState _)
-  = Cell
-  { cellState = migrate newState oldState
-  , cellStep  = newStep
-  }
+  (Cell oldState _) =
+    Cell
+      { cellState = migrate newState oldState,
+        cellStep = newStep
+      }

--- a/essence-of-live-coding/src/LiveCoding/Cell/Monad.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/Monad.hs
@@ -1,58 +1,64 @@
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RankNTypes #-}
-{- |
-Handling monad morphisms.
--}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
+
+-- |
+-- Handling monad morphisms.
 module LiveCoding.Cell.Monad where
 
 -- essence-of-live-coding
-import LiveCoding.Cell
-import Control.Arrow ((>>>), Arrow(arr))
+
+import Control.Arrow (Arrow (arr), (>>>))
 import Data.Data (Data)
+import LiveCoding.Cell
 
 -- | Apply a monad morphism that also transforms the output to a cell.
-hoistCellOutput
-  :: (Monad m1, Monad m2)
-  => (forall s . m1 (b1, s) -> m2 (b2, s))
-  -> Cell m1 a b1
-  -> Cell m2 a b2
+hoistCellOutput ::
+  (Monad m1, Monad m2) =>
+  (forall s. m1 (b1, s) -> m2 (b2, s)) ->
+  Cell m1 a b1 ->
+  Cell m2 a b2
 hoistCellOutput morph = hoistCellKleisli_ (morph .)
 
 -- | Apply a transformation of Kleisli morphisms to a cell.
-hoistCellKleisli_
-  :: (Monad m1, Monad m2)
-  => (forall s . (a1 -> m1 (b1, s)) -> (a2 -> m2 (b2, s)))
-  -> Cell m1 a1 b1
-  -> Cell m2 a2 b2
+hoistCellKleisli_ ::
+  (Monad m1, Monad m2) =>
+  (forall s. (a1 -> m1 (b1, s)) -> (a2 -> m2 (b2, s))) ->
+  Cell m1 a1 b1 ->
+  Cell m2 a2 b2
 hoistCellKleisli_ morph = hoistCellKleisli (morph .)
 
 -- | Apply a transformation of stateful Kleisli morphisms to a cell.
-hoistCellKleisli
-  :: (Monad m1, Monad m2)
-  => (forall s . (s -> a1 -> m1 (b1, s)) -> (s -> a2 -> m2 (b2, s)))
-  -> Cell m1 a1 b1
-  -> Cell m2 a2 b2
-hoistCellKleisli morph ArrM { .. } = ArrM
-  { runArrM = (fmap fst .) $ ($ ()) $ morph $ const $ runArrM >>> fmap ( , ())
-  }
-hoistCellKleisli morph Cell { .. } = Cell
-  { cellStep = morph cellStep
-  , ..
-  }
+hoistCellKleisli ::
+  (Monad m1, Monad m2) =>
+  (forall s. (s -> a1 -> m1 (b1, s)) -> (s -> a2 -> m2 (b2, s))) ->
+  Cell m1 a1 b1 ->
+  Cell m2 a2 b2
+hoistCellKleisli morph ArrM {..} =
+  ArrM
+    { runArrM = (fmap fst .) $ ($ ()) $ morph $ const $ runArrM >>> fmap (,())
+    }
+hoistCellKleisli morph Cell {..} =
+  Cell
+    { cellStep = morph cellStep,
+      ..
+    }
 
 -- | Apply a transformation of stateful Kleisli morphisms to a cell,
 --   changing the state type.
-hoistCellKleisliStateChange
-  :: (Monad m1, Monad m2, (forall s . Data s => Data (t s)))
-  => (forall s . (  s -> a1 -> m1 (b1,   s))
-              -> (t s -> a2 -> m2 (b2, t s)))
-  -> (forall s . (s -> t s))
-  -> Cell m1 a1 b1
-  -> Cell m2 a2 b2
-hoistCellKleisliStateChange morph init Cell { .. } = Cell
-  { cellStep  = morph cellStep
-  , cellState = init cellState
-  }
+hoistCellKleisliStateChange ::
+  (Monad m1, Monad m2, (forall s. Data s => Data (t s))) =>
+  ( forall s.
+    (s -> a1 -> m1 (b1, s)) ->
+    (t s -> a2 -> m2 (b2, t s))
+  ) ->
+  (forall s. (s -> t s)) ->
+  Cell m1 a1 b1 ->
+  Cell m2 a2 b2
+hoistCellKleisliStateChange morph init Cell {..} =
+  Cell
+    { cellStep = morph cellStep,
+      cellState = init cellState
+    }
 hoistCellKleisliStateChange morph init cell = hoistCellKleisliStateChange morph init $ toCell cell

--- a/essence-of-live-coding/src/LiveCoding/Cell/Monad/Trans.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/Monad/Trans.hs
@@ -1,68 +1,66 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{- |
-Handling monad transformers.
--}
+{-# LANGUAGE RecordWildCards #-}
+
+-- |
+-- Handling monad transformers.
 module LiveCoding.Cell.Monad.Trans where
 
 -- base
 import Control.Arrow (arr, (>>>))
-import Data.Data (Data)
-
 -- transformers
-import Control.Monad.Trans.Reader (runReaderT, ReaderT)
-import Control.Monad.Trans.State.Strict (StateT (..), runStateT, evalStateT)
+import Control.Monad.Trans.Reader (ReaderT, runReaderT)
+import Control.Monad.Trans.State.Strict (StateT (..), evalStateT, runStateT)
 import Control.Monad.Trans.Writer.Strict
-
+import Data.Data (Data)
 -- essence-of-live-coding
 import LiveCoding.Cell
 import LiveCoding.Cell.Monad
 
 -- | Push effectful state into the internal state of a cell
-runStateC
-  :: (Data stateT, Monad m)
-  => Cell (StateT stateT m) a  b
-  -- ^ A cell with a state effect
-  -> stateT
-  -- ^ The initial state
-  -> Cell                m  a (b, stateT)
-  -- ^ The cell, returning its current state
+runStateC ::
+  (Data stateT, Monad m) =>
+  -- | A cell with a state effect
+  Cell (StateT stateT m) a b ->
+  -- | The initial state
+  stateT ->
+  -- | The cell, returning its current state
+  Cell m a (b, stateT)
 runStateC cell stateT = hoistCellKleisliStateChange morph init cell
   where
-    morph step State { .. } a = do
+    morph step State {..} a = do
       ((b, stateInternal), stateT) <- runStateT (step stateInternal a) stateT
-      return ((b, stateT), State { .. })
-    init stateInternal = State { .. }
+      return ((b, stateT), State {..})
+    init stateInternal = State {..}
 
 -- | Like 'runStateC', but does not return the current state.
-runStateC_
-  :: (Data stateT, Monad m)
-  => Cell (StateT stateT m) a b
-  -- ^ A cell with a state effect
-  -> stateT
-  -- ^ The initial state
-  -> Cell                m  a b
+runStateC_ ::
+  (Data stateT, Monad m) =>
+  -- | A cell with a state effect
+  Cell (StateT stateT m) a b ->
+  -- | The initial state
+  stateT ->
+  Cell m a b
 runStateC_ cell stateT = runStateC cell stateT >>> arr fst
 
 -- | The internal state of a cell to which 'runStateC' or 'runStateL' has been applied.
 data State stateT stateInternal = State
-  { stateT :: stateT
-  , stateInternal :: stateInternal
+  { stateT :: stateT,
+    stateInternal :: stateInternal
   }
   deriving (Data, Eq, Show)
 
 -- | Supply a 'ReaderT' environment before running the cell
-runReaderC
-  ::               r
-  -> Cell (ReaderT r m) a b
-  -> Cell            m  a b
+runReaderC ::
+  r ->
+  Cell (ReaderT r m) a b ->
+  Cell m a b
 runReaderC r = hoistCell $ flip runReaderT r
 
 -- | Supply a 'ReaderT' environment live
-runReaderC'
-  :: Monad m
-  => Cell (ReaderT r m) a b
-  -> Cell m (r, a) b
+runReaderC' ::
+  Monad m =>
+  Cell (ReaderT r m) a b ->
+  Cell m (r, a) b
 runReaderC' = hoistCellKleisli_ $ \action (r, a) -> runReaderT (action a) r
 
 -- | Run the effects of the 'WriterT' monad,

--- a/essence-of-live-coding/src/LiveCoding/Cell/NonBlocking.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/NonBlocking.hs
@@ -2,15 +2,14 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module LiveCoding.Cell.NonBlocking
-  ( nonBlocking
+  ( nonBlocking,
   )
-  where
+where
 
 -- base
 import Control.Concurrent
-import Control.Monad ((>=>), void, when)
+import Control.Monad (void, when, (>=>))
 import Data.Data
-
 -- essence-of-live-coding
 import LiveCoding.Cell
 import LiveCoding.Handle
@@ -18,50 +17,51 @@ import LiveCoding.Handle.Examples
 import LiveCoding.HandlingState
 
 threadVarHandle :: Handle IO (MVar ThreadId)
-threadVarHandle = Handle
-  { create = newEmptyMVar
-  , destroy = tryTakeMVar >=> mapM_ killThread
-  }
+threadVarHandle =
+  Handle
+    { create = newEmptyMVar,
+      destroy = tryTakeMVar >=> mapM_ killThread
+    }
 
-{- | Wrap a cell in a non-blocking way.
-Every incoming sample of @nonBlocking cell@ results in an immediate output,
-either @Just b@ if the value was computed since the last poll,
-or @Nothing@ if no new value was computed yet.
-The resulting cell can be polled by sending 'Nothing'.
-The boolean flag controls whether the current computation is aborted and restarted when new data arrives.
--}
-nonBlocking
-  :: Typeable b
-  => Bool
-  -- ^ Pass 'True' to abort the computation when new data arrives. 'False' discards new data.
-  -> Cell IO a b
-  -> Cell (HandlingStateT IO) (Maybe a) (Maybe b)
-nonBlocking abort Cell { .. } = proc aMaybe -> do
-  threadVar <- handling threadVarHandle            -< ()
-  resultVar <- handling emptyMVarHandle            -< ()
-  liftCell Cell { cellStep = nonBlockingStep, .. } -< (aMaybe, threadVar, resultVar)
-    where
-      nonBlockingStep s (Nothing, threadVar, resultVar) = do
-        bsMaybe <- tryTakeMVar resultVar
-        case bsMaybe of
-          Just (b, s') -> do
-            threadId <- takeMVar threadVar
-            killThread threadId
-            return (Just b, s')
-          Nothing -> return (Nothing, s)
-      nonBlockingStep s (Just a, threadVar, resultVar) = do
-        noThreadRunning <- if abort
-            -- Abort the current computation if it is still running
-          then do
+-- | Wrap a cell in a non-blocking way.
+-- Every incoming sample of @nonBlocking cell@ results in an immediate output,
+-- either @Just b@ if the value was computed since the last poll,
+-- or @Nothing@ if no new value was computed yet.
+-- The resulting cell can be polled by sending 'Nothing'.
+-- The boolean flag controls whether the current computation is aborted and restarted when new data arrives.
+nonBlocking ::
+  Typeable b =>
+  -- | Pass 'True' to abort the computation when new data arrives. 'False' discards new data.
+  Bool ->
+  Cell IO a b ->
+  Cell (HandlingStateT IO) (Maybe a) (Maybe b)
+nonBlocking abort Cell {..} = proc aMaybe -> do
+  threadVar <- handling threadVarHandle -< ()
+  resultVar <- handling emptyMVarHandle -< ()
+  liftCell Cell {cellStep = nonBlockingStep, ..} -< (aMaybe, threadVar, resultVar)
+  where
+    nonBlockingStep s (Nothing, threadVar, resultVar) = do
+      bsMaybe <- tryTakeMVar resultVar
+      case bsMaybe of
+        Just (b, s') -> do
+          threadId <- takeMVar threadVar
+          killThread threadId
+          return (Just b, s')
+        Nothing -> return (Nothing, s)
+    nonBlockingStep s (Just a, threadVar, resultVar) = do
+      noThreadRunning <-
+        if abort
+          then -- Abort the current computation if it is still running
+          do
             maybeThreadId <- tryTakeMVar threadVar
             mapM_ killThread maybeThreadId
             return True
-          -- No computation currently running
-          else isEmptyMVar threadVar
-        when noThreadRunning $ do
-          threadId <- forkIO $ putMVar resultVar =<< cellStep s a
-          putMVar threadVar threadId
-        nonBlockingStep s (Nothing, threadVar, resultVar)
+          else -- No computation currently running
+            isEmptyMVar threadVar
+      when noThreadRunning $ do
+        threadId <- forkIO $ putMVar resultVar =<< cellStep s a
+        putMVar threadVar threadId
+      nonBlockingStep s (Nothing, threadVar, resultVar)
 
 -- It would have been nice to refactor this with 'hoistCellKleisli',
 -- but that would expose the existential state type to the handle.

--- a/essence-of-live-coding/src/LiveCoding/Cell/Util/Internal.hs
+++ b/essence-of-live-coding/src/LiveCoding/Cell/Util/Internal.hs
@@ -4,4 +4,4 @@ module LiveCoding.Cell.Util.Internal where
 whenDifferent :: (Eq p, Monad m) => (p -> p -> a -> m b) -> (p, p, a) -> m (Maybe b)
 whenDifferent action (pOld, pNew, a)
   | pOld == pNew = Just <$> action pOld pNew a
-  | otherwise    = return Nothing
+  | otherwise = return Nothing

--- a/essence-of-live-coding/src/LiveCoding/External.hs
+++ b/essence-of-live-coding/src/LiveCoding/External.hs
@@ -1,21 +1,18 @@
-{- |
-Utilities for integrating live programs into external loops, using 'IO' concurrency.
-The basic idea is two wormholes (see Winograd-Court's thesis).
--}
-
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE RecordWildCards #-}
+
+-- |
+-- Utilities for integrating live programs into external loops, using 'IO' concurrency.
+-- The basic idea is two wormholes (see Winograd-Court's thesis).
 module LiveCoding.External where
 
 -- base
 import Control.Arrow
 import Control.Concurrent
 import Control.Monad.IO.Class
-
 -- transformers
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Writer.Strict
-
 -- essence-of-live-coding
 import LiveCoding.Cell
 import LiveCoding.Cell.Monad.Trans
@@ -27,15 +24,14 @@ type ExternalLoop eIn eOut = Cell IO eIn eOut
 
 concurrently :: (MonadIO m, Monoid eOut) => ExternalCell m eIn eOut a b -> IO (Cell m a b, ExternalLoop eIn eOut)
 concurrently externalCell = do
-  inVar  <- newEmptyMVar
+  inVar <- newEmptyMVar
   outVar <- newEmptyMVar
-  let
-    cell = proc a -> do
-      eIn       <- constM (liftIO $ takeMVar inVar)      -< ()
-      (eOut, b) <- runWriterC (runReaderC' externalCell) -< (eIn, a)
-      arrM (liftIO . putMVar outVar)                     -< eOut
-      returnA                                            -< b
-    externalLoop = arrM (putMVar inVar) >>> constM (takeMVar outVar)
+  let cell = proc a -> do
+        eIn <- constM (liftIO $ takeMVar inVar) -< ()
+        (eOut, b) <- runWriterC (runReaderC' externalCell) -< (eIn, a)
+        arrM (liftIO . putMVar outVar) -< eOut
+        returnA -< b
+      externalLoop = arrM (putMVar inVar) >>> constM (takeMVar outVar)
   return (cell, externalLoop)
 
 type CellHandle a b = MVar (Cell IO a b)

--- a/essence-of-live-coding/src/LiveCoding/GHCi.hs
+++ b/essence-of-live-coding/src/LiveCoding/GHCi.hs
@@ -1,30 +1,27 @@
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{- | Support functions to call common live coding functionalities like launching and reloading
-from a @ghci@ or @cabal repl@ session.
 
-You typically don't need to import this module in your code,
-but you should load it in your interactive session,
-ideally by copying the file `essence-of-live-coding/.ghci` to your project,
-adjusting it to your needs and launching @cabal repl@.
--}
+-- | Support functions to call common live coding functionalities like launching and reloading
+-- from a @ghci@ or @cabal repl@ session.
+--
+-- You typically don't need to import this module in your code,
+-- but you should load it in your interactive session,
+-- ideally by copying the file `essence-of-live-coding/.ghci` to your project,
+-- adjusting it to your needs and launching @cabal repl@.
 module LiveCoding.GHCi where
 
 -- base
 import Control.Concurrent
-import Control.Exception (SomeException, try, Exception (toException, displayException))
-import Control.Monad (void, (>=>), join)
-import Data.Data
-import Data.Function ((&))
-
+import Control.Exception (Exception (displayException, toException), SomeException, try)
+import Control.Monad (join, void, (>=>))
 -- transformers
 import Control.Monad.Trans.State.Strict
-
+import Data.Data
+import Data.Function ((&))
 -- foreign-store
 import Foreign.Store
-
 -- essence-of-live-coding
 import LiveCoding.LiveProgram
 import LiveCoding.RuntimeIO.Launch
@@ -34,7 +31,7 @@ proxyFromLiveProgram _ = Proxy
 
 -- | An exception type marking the absence of a foreign store of the correct type.
 data NoStore = NoStore
-  deriving Show
+  deriving (Show)
 
 instance Exception NoStore
 
@@ -43,10 +40,10 @@ instance Exception NoStore
 -- | Try to retrieve a 'LiveProgram' of a given type from the 'Store',
 --   handling all 'IO' exceptions.
 --   Returns 'Right Nothing' if the store didn't exist.
-possiblyLaunchedProgram
-  :: Launchable m
-  => Proxy m
-  -> IO (Either SomeException (LaunchedProgram m))
+possiblyLaunchedProgram ::
+  Launchable m =>
+  Proxy m ->
+  IO (Either SomeException (LaunchedProgram m))
 possiblyLaunchedProgram _ = do
   storeMaybe <- lookupStore 0
   fmap join $ try $ traverse readStore $ maybe (Left $ toException NoStore) Right storeMaybe
@@ -77,10 +74,10 @@ save = writeStore $ Store 0
 
 -- | Try to retrieve a 'LaunchedProgram' from the 'Store',
 --   and if successful, stop it.
-stopStored
-  :: Launchable m
-  => Proxy m
-  -> IO ()
+stopStored ::
+  Launchable m =>
+  Proxy m ->
+  IO ()
 stopStored proxy = do
   launchedProgramPossibly <- possiblyLaunchedProgram proxy
   either (putStrLn . displayException) stop launchedProgramPossibly
@@ -88,15 +85,18 @@ stopStored proxy = do
 -- * GHCi commands
 
 -- ** Debugging
+
 -- TODO Could also parametrise this and all other commands by the 'liveProgram'
 
 -- | Initialise a launched program in the store,
 --   but don't start it.
-liveinit _ = return $ unlines
-  [ "programVar <- newMVar liveProgram"
-  , "threadId <- myThreadId"
-  , "save LaunchedProgram { .. }"
-  ]
+liveinit _ =
+  return $
+    unlines
+      [ "programVar <- newMVar liveProgram",
+        "threadId <- myThreadId",
+        "save LaunchedProgram { .. }"
+      ]
 
 -- | Run one program step, assuming you have a launched program in a variable @launchedProgram@.
 livestep _ = return "stepLaunchedProgram launchedProgram"
@@ -107,10 +107,12 @@ livestep _ = return "stepLaunchedProgram launchedProgram"
 livelaunch _ = return "sync liveProgram"
 
 -- | Reload the code and do hot code swap and migration.
-livereload _ = return $ unlines
-  [ ":reload"
-  , "sync liveProgram"
-  ]
+livereload _ =
+  return $
+    unlines
+      [ ":reload",
+        "sync liveProgram"
+      ]
 
 -- | Stop the program.
 livestop _ = return "stopStored $ proxyFromLiveProgram liveProgram"

--- a/essence-of-live-coding/src/LiveCoding/Handle.hs
+++ b/essence-of-live-coding/src/LiveCoding/Handle.hs
@@ -8,162 +8,161 @@ module LiveCoding.Handle where
 
 -- base
 import Control.Arrow (arr, (>>>))
-import Data.Data
-
 -- transformers
-import Control.Monad.Trans.Class (MonadTrans(lift))
 
 -- mmorph
 import Control.Monad.Morph
-
+import Control.Monad.Trans.Class (MonadTrans (lift))
+import Data.Data
 -- essence-of-live-coding
 import LiveCoding.Cell
 import LiveCoding.HandlingState
 import LiveCoding.Migrate.NoMigration
 
-{- | Container for unserialisable values,
-such as 'IORef's, threads, 'MVar's, pointers, and device handles.
-
-In a 'Handle', you can store a mechanism to create and destroy a value
-that survives reloads occuring during live coding
-even if does not have a 'Data' instance.
-Using the function 'handling', you can create a cell that will
-automatically initialise your value,
-and register it in the 'HandlingStateT' monad transformer,
-which takes care of automatically destroying it (if necessary) when it does not occur anymore in a later revision of your live program.
-
-Have a look at 'LiveCoding.Handle.Examples' for some ready-to-use implementations.
-
-In short, 'Handle' is an opaque, automatically constructing and garbage collecting container for arbitrary values in the live coding environment.
--}
+-- | Container for unserialisable values,
+-- such as 'IORef's, threads, 'MVar's, pointers, and device handles.
+--
+-- In a 'Handle', you can store a mechanism to create and destroy a value
+-- that survives reloads occuring during live coding
+-- even if does not have a 'Data' instance.
+-- Using the function 'handling', you can create a cell that will
+-- automatically initialise your value,
+-- and register it in the 'HandlingStateT' monad transformer,
+-- which takes care of automatically destroying it (if necessary) when it does not occur anymore in a later revision of your live program.
+--
+-- Have a look at 'LiveCoding.Handle.Examples' for some ready-to-use implementations.
+--
+-- In short, 'Handle' is an opaque, automatically constructing and garbage collecting container for arbitrary values in the live coding environment.
 data Handle m h = Handle
-  { create :: m h
-  , destroy :: h -> m ()
+  { create :: m h,
+    destroy :: h -> m ()
   }
 
 instance MFunctor Handle where
-  hoist morphism Handle { .. } = Handle
-    { create = morphism create
-    , destroy = morphism . destroy
+  hoist morphism Handle {..} =
+    Handle
+      { create = morphism create,
+        destroy = morphism . destroy
+      }
+
+-- | Combine two handles to one.
+--
+-- 'Handle's are not quite 'Monoid's because of the extra type parameter,
+-- but it is possible to combine them.
+-- In the combined handle, the first handle is created first and destroyed last.
+--
+-- Note: 'Handle' is not an 'Applicative' because it is not a 'Functor'
+-- (because the destructor is contravariant in @h@).
+combineHandles :: Applicative m => Handle m h1 -> Handle m h2 -> Handle m (h1, h2)
+combineHandles handle1 handle2 =
+  Handle
+    { create = (,) <$> create handle1 <*> create handle2,
+      destroy = \(h1, h2) -> destroy handle2 h2 *> destroy handle1 h1
     }
 
-{- | Combine two handles to one.
-
-'Handle's are not quite 'Monoid's because of the extra type parameter,
-but it is possible to combine them.
-In the combined handle, the first handle is created first and destroyed last.
-
-Note: 'Handle' is not an 'Applicative' because it is not a 'Functor'
-(because the destructor is contravariant in @h@).
--}
-combineHandles :: Applicative m => Handle m h1 -> Handle m h2 -> Handle m (h1, h2)
-combineHandles handle1 handle2 = Handle
-  { create = ( , ) <$> create handle1 <*> create handle2
-  , destroy = \(h1, h2) -> destroy handle2 h2 *> destroy handle1 h1
-  }
-
-{- | Hide a handle in a cell,
-taking care of initialisation and destruction.
-
-Upon the first tick (or directly after migration),
-the 'create' method of the 'Handle' is called,
-and the result stored.
-This result is then not changed anymore until the cell is removed again.
-Once it is removed, the destructor will be called on the next tick.
-
-Migrations will by default not inspect the interior of a 'handling' cell.
-This means that handles are only migrated if they have exactly the same type.
--}
-handling
-  :: ( Typeable h
-     , Monad m
-     )
-  => Handle m h
-  -> Cell (HandlingStateT m) arbitrary h
+-- | Hide a handle in a cell,
+-- taking care of initialisation and destruction.
+--
+-- Upon the first tick (or directly after migration),
+-- the 'create' method of the 'Handle' is called,
+-- and the result stored.
+-- This result is then not changed anymore until the cell is removed again.
+-- Once it is removed, the destructor will be called on the next tick.
+--
+-- Migrations will by default not inspect the interior of a 'handling' cell.
+-- This means that handles are only migrated if they have exactly the same type.
+handling ::
+  ( Typeable h,
+    Monad m
+  ) =>
+  Handle m h ->
+  Cell (HandlingStateT m) arbitrary h
 handling handle = arr (const ()) >>> handlingParametrised (toParametrised handle)
 
-{- | Generalisation of 'Handle' carrying an additional parameter which may change at runtime.
-
-Like in a 'Handle', the @h@ value of a 'ParametrisedHandle' is preserved through live coding reloads.
-Additionally, the parameter @p@ value can be adjusted,
-and triggers a destruction and reinitialisation whenever it changes.
--}
+-- | Generalisation of 'Handle' carrying an additional parameter which may change at runtime.
+--
+-- Like in a 'Handle', the @h@ value of a 'ParametrisedHandle' is preserved through live coding reloads.
+-- Additionally, the parameter @p@ value can be adjusted,
+-- and triggers a destruction and reinitialisation whenever it changes.
 data ParametrisedHandle p m h = ParametrisedHandle
-  { createParametrised :: p -> m h
-  , changeParametrised :: p -> p -> h -> m h
-  , destroyParametrised :: p -> h -> m ()
+  { createParametrised :: p -> m h,
+    changeParametrised :: p -> p -> h -> m h,
+    destroyParametrised :: p -> h -> m ()
   }
 
 instance MFunctor (ParametrisedHandle p) where
-  hoist morphism ParametrisedHandle { .. } = ParametrisedHandle
-    { createParametrised = morphism . createParametrised
-    , changeParametrised = ((morphism .) .) . changeParametrised
-    , destroyParametrised = (morphism .) . destroyParametrised
-    }
+  hoist morphism ParametrisedHandle {..} =
+    ParametrisedHandle
+      { createParametrised = morphism . createParametrised,
+        changeParametrised = ((morphism .) .) . changeParametrised,
+        destroyParametrised = (morphism .) . destroyParametrised
+      }
 
 -- | Given the methods 'createParametrised' and 'destroyParametrised',
 --   build a fitting method for 'changeParametrised' which
 defaultChange :: (Eq p, Monad m) => (p -> m h) -> (p -> h -> m ()) -> p -> p -> h -> m h
 defaultChange creator destructor pOld pNew h
   | pOld == pNew = return h
-  | otherwise    = do
+  | otherwise = do
       destructor pOld h
       creator pNew
 
 -- | Like 'combineHandles', but for 'ParametrisedHandle's.
-combineParametrisedHandles
-  :: Applicative m
-  => ParametrisedHandle  p1      m  h1
-  -> ParametrisedHandle      p2  m      h2
-  -> ParametrisedHandle (p1, p2) m (h1, h2)
-combineParametrisedHandles handle1 handle2 = ParametrisedHandle
-  { createParametrised = \(p1, p2) -> ( , ) <$> createParametrised handle1 p1 <*> createParametrised handle2 p2
-  , changeParametrised = \(pOld1, pOld2) (pNew1, pNew2) (h1, h2) -> ( , ) <$> changeParametrised handle1 pOld1 pNew1 h1 <*> changeParametrised handle2 pOld2 pNew2 h2
-  , destroyParametrised = \(p1, p2) (h1, h2) -> destroyParametrised handle1 p1 h1 *> destroyParametrised handle2 p2 h2
-  }
+combineParametrisedHandles ::
+  Applicative m =>
+  ParametrisedHandle p1 m h1 ->
+  ParametrisedHandle p2 m h2 ->
+  ParametrisedHandle (p1, p2) m (h1, h2)
+combineParametrisedHandles handle1 handle2 =
+  ParametrisedHandle
+    { createParametrised = \(p1, p2) -> (,) <$> createParametrised handle1 p1 <*> createParametrised handle2 p2,
+      changeParametrised = \(pOld1, pOld2) (pNew1, pNew2) (h1, h2) -> (,) <$> changeParametrised handle1 pOld1 pNew1 h1 <*> changeParametrised handle2 pOld2 pNew2 h2,
+      destroyParametrised = \(p1, p2) (h1, h2) -> destroyParametrised handle1 p1 h1 *> destroyParametrised handle2 p2 h2
+    }
 
-{- | Hide a 'ParametrisedHandle' in a cell,
-taking care of initialisation and destruction.
-
-Upon the first tick, directly after migration, and after each parameter change,
-the 'create' method of the 'Handle' is called,
-and the result stored.
-This result is then not changed anymore until the cell is removed again, or the parameter changes.
-A parameter change triggers the destructor immediately,
-but if the cell is removed, the destructor will be called on the next tick.
-
-Migrations will by default not inspect the interior of a 'handling' cell.
-This means that parametrised handles are only migrated if they have exactly the same type.
--}
-handlingParametrised
-  :: ( Typeable h, Typeable p
-     , Monad m
-     , Eq p
-     )
-  => ParametrisedHandle p m h
-  -> Cell (HandlingStateT m) p h
-handlingParametrised handleImpl@ParametrisedHandle { .. } = Cell { .. }
+-- | Hide a 'ParametrisedHandle' in a cell,
+-- taking care of initialisation and destruction.
+--
+-- Upon the first tick, directly after migration, and after each parameter change,
+-- the 'create' method of the 'Handle' is called,
+-- and the result stored.
+-- This result is then not changed anymore until the cell is removed again, or the parameter changes.
+-- A parameter change triggers the destructor immediately,
+-- but if the cell is removed, the destructor will be called on the next tick.
+--
+-- Migrations will by default not inspect the interior of a 'handling' cell.
+-- This means that parametrised handles are only migrated if they have exactly the same type.
+handlingParametrised ::
+  ( Typeable h,
+    Typeable p,
+    Monad m,
+    Eq p
+  ) =>
+  ParametrisedHandle p m h ->
+  Cell (HandlingStateT m) p h
+handlingParametrised handleImpl@ParametrisedHandle {..} = Cell {..}
   where
     cellState = Uninitialized
     cellStep Uninitialized parameter = do
       mereHandle <- lift $ createParametrised parameter
       let handle = (mereHandle, parameter)
       key <- register $ destroyParametrised parameter mereHandle
-      return (mereHandle, Initialized Handling { handle = handle, .. })
-    cellStep handling@(Initialized Handling { handle = (mereHandle, lastParameter), .. }) parameter
+      return (mereHandle, Initialized Handling {handle = handle, ..})
+    cellStep handling@(Initialized Handling {handle = (mereHandle, lastParameter), ..}) parameter
       | parameter == lastParameter = do
           reregister (destroyParametrised parameter mereHandle) key
           return (mereHandle, handling)
       | otherwise = do
           mereHandle <- lift $ changeParametrised lastParameter parameter mereHandle
           reregister (destroyParametrised parameter mereHandle) key
-          return (mereHandle, Initialized Handling { handle = (mereHandle, parameter), .. })
+          return (mereHandle, Initialized Handling {handle = (mereHandle, parameter), ..})
 
 -- | Every 'Handle' is trivially a 'ParametrisedHandle'
 --   when the parameter is the trivial type.
 toParametrised :: Monad m => Handle m h -> ParametrisedHandle () m h
-toParametrised Handle { .. } = ParametrisedHandle
-  { createParametrised = const create
-  , changeParametrised = const $ const return
-  , destroyParametrised = const destroy
-  }
+toParametrised Handle {..} =
+  ParametrisedHandle
+    { createParametrised = const create,
+      changeParametrised = const $ const return,
+      destroyParametrised = const destroy
+    }

--- a/essence-of-live-coding/src/LiveCoding/Handle/Examples.hs
+++ b/essence-of-live-coding/src/LiveCoding/Handle/Examples.hs
@@ -4,36 +4,39 @@ module LiveCoding.Handle.Examples where
 import Control.Concurrent
 import Data.Data
 import Data.IORef
-
 -- essence-of-live-coding
 import LiveCoding.Handle
 
 -- | Create an 'IORef', with no special cleanup action.
 ioRefHandle :: a -> Handle IO (IORef a)
-ioRefHandle a = Handle
-  { create = newIORef a
-  , destroy = const $ return () -- IORefs are garbage collected
-  }
+ioRefHandle a =
+  Handle
+    { create = newIORef a,
+      destroy = const $ return () -- IORefs are garbage collected
+    }
 
 -- | Create an uninitialised 'MVar', with no special cleanup action.
 emptyMVarHandle :: Handle IO (MVar a)
-emptyMVarHandle = Handle
-  { create = newEmptyMVar
-  , destroy = const $ return () -- MVars are garbage collected
-  }
+emptyMVarHandle =
+  Handle
+    { create = newEmptyMVar,
+      destroy = const $ return () -- MVars are garbage collected
+    }
 
 -- | Create an 'MVar' initialised to some value @a@,
 --   with no special cleanup action.
 newMVarHandle :: a -> Handle IO (MVar a)
-newMVarHandle a = Handle
-  { create = newMVar a
-  , destroy = const $ return () -- MVars are garbage collected
-  }
+newMVarHandle a =
+  Handle
+    { create = newMVar a,
+      destroy = const $ return () -- MVars are garbage collected
+    }
 
 -- | Launch a thread executing the given action
 --   and kill it when the handle is removed.
 threadHandle :: IO () -> Handle IO ThreadId
-threadHandle action = Handle
-  { create  = forkIO action
-  , destroy = killThread
-  }
+threadHandle action =
+  Handle
+    { create = forkIO action,
+      destroy = killThread
+    }

--- a/essence-of-live-coding/src/LiveCoding/HandlingState.hs
+++ b/essence-of-live-coding/src/LiveCoding/HandlingState.hs
@@ -6,18 +6,15 @@
 module LiveCoding.HandlingState where
 
 -- base
-import Control.Arrow (returnA, arr, (>>>))
-import Data.Data
-
+import Control.Arrow (arr, returnA, (>>>))
 -- transformers
-import Control.Monad.Trans.Class (MonadTrans(lift))
+import Control.Monad.Trans.Class (MonadTrans (lift))
 import Control.Monad.Trans.State.Strict
+import Data.Data
 import Data.Foldable (traverse_)
-
 -- containers
 import Data.IntMap
 import qualified Data.IntMap as IntMap
-
 -- essence-of-live-coding
 import LiveCoding.Cell
 import LiveCoding.Cell.Monad
@@ -26,18 +23,18 @@ import LiveCoding.LiveProgram
 import LiveCoding.LiveProgram.Monad.Trans
 
 data Handling h = Handling
-  { key    :: Key
-  , handle :: h
+  { key :: Key,
+    handle :: h
   }
 
 type Destructors m = IntMap (Destructor m)
 
 -- | Hold a map of registered handle keys and destructors
 data HandlingState m = HandlingState
-  { nHandles    :: Key
-  , destructors :: Destructors m
+  { nHandles :: Key,
+    destructors :: Destructors m
   }
-  deriving Data
+  deriving (Data)
 
 -- | In this monad, handles can be registered,
 --   and their destructors automatically executed.
@@ -45,118 +42,124 @@ data HandlingState m = HandlingState
 type HandlingStateT m = StateT (HandlingState m) m
 
 initHandlingState :: HandlingState m
-initHandlingState = HandlingState
-  { nHandles = 0
-  , destructors = IntMap.empty
-  }
+initHandlingState =
+  HandlingState
+    { nHandles = 0,
+      destructors = IntMap.empty
+    }
 
 -- | Handle the 'HandlingStateT' effect _without_ garbage collection.
 --   Apply this to your main loop after calling 'foreground'.
 --   Since there is no garbage collection, don't use this function for live coding.
-runHandlingStateT
-  :: Monad m
-  => HandlingStateT m a
-  -> m a
+runHandlingStateT ::
+  Monad m =>
+  HandlingStateT m a ->
+  m a
 runHandlingStateT = flip evalStateT initHandlingState
 
-{- | Apply this to your main live cell before passing it to the runtime.
-
-On the first tick, it initialises the 'HandlingState' at "no handles".
-
-On every step, it does:
-
-1. Unregister all handles
-2. Register currently present handles
-3. Destroy all still unregistered handles
-   (i.e. those that were removed in the last tick)
--}
-runHandlingStateC
-  :: forall m a b .
-     (Monad m, Typeable m)
-  => Cell (HandlingStateT m) a b
-  -> Cell                 m  a b
-runHandlingStateC cell = flip runStateC_ initHandlingState
-  $ hoistCellOutput garbageCollected cell
+-- | Apply this to your main live cell before passing it to the runtime.
+--
+-- On the first tick, it initialises the 'HandlingState' at "no handles".
+--
+-- On every step, it does:
+--
+-- 1. Unregister all handles
+-- 2. Register currently present handles
+-- 3. Destroy all still unregistered handles
+--   (i.e. those that were removed in the last tick)
+runHandlingStateC ::
+  forall m a b.
+  (Monad m, Typeable m) =>
+  Cell (HandlingStateT m) a b ->
+  Cell m a b
+runHandlingStateC cell =
+  flip runStateC_ initHandlingState $
+    hoistCellOutput garbageCollected cell
 
 -- | Like 'runHandlingStateC', but for whole live programs.
-runHandlingState
-  :: (Monad m, Typeable m)
-  => LiveProgram (HandlingStateT m)
-  -> LiveProgram                 m
-runHandlingState LiveProgram { .. } = flip runStateL initHandlingState LiveProgram
-  { liveStep = garbageCollected . liveStep
-  , ..
-  }
+runHandlingState ::
+  (Monad m, Typeable m) =>
+  LiveProgram (HandlingStateT m) ->
+  LiveProgram m
+runHandlingState LiveProgram {..} =
+  flip
+    runStateL
+    initHandlingState
+    LiveProgram
+      { liveStep = garbageCollected . liveStep,
+        ..
+      }
 
-garbageCollected
-  :: Monad m
-  => HandlingStateT m a
-  -> HandlingStateT m a
+garbageCollected ::
+  Monad m =>
+  HandlingStateT m a ->
+  HandlingStateT m a
 garbageCollected action = unregisterAll >> action <* destroyUnregistered
 
 data Destructor m = Destructor
-  { isRegistered :: Bool
-  , action       :: m ()
+  { isRegistered :: Bool,
+    action :: m ()
   }
 
-
-register
-  :: Monad m
-  => m () -- ^ Destructor
-  -> HandlingStateT m Key
+register ::
+  Monad m =>
+  -- | Destructor
+  m () ->
+  HandlingStateT m Key
 register destructor = do
-  HandlingState { .. } <- get
+  HandlingState {..} <- get
   let key = nHandles + 1
-  put HandlingState
-    { nHandles = key
-    , destructors = insertDestructor destructor key destructors
-    }
+  put
+    HandlingState
+      { nHandles = key,
+        destructors = insertDestructor destructor key destructors
+      }
   return key
 
-reregister
-  :: Monad m
-  => m ()
-  -> Key
-  -> HandlingStateT m ()
+reregister ::
+  Monad m =>
+  m () ->
+  Key ->
+  HandlingStateT m ()
 reregister action key = do
-  HandlingState { .. } <- get
-  put HandlingState { destructors = insertDestructor action key destructors, .. }
+  HandlingState {..} <- get
+  put HandlingState {destructors = insertDestructor action key destructors, ..}
 
-insertDestructor
-  :: m ()
-  -> Key
-  -> Destructors m
-  -> Destructors m
+insertDestructor ::
+  m () ->
+  Key ->
+  Destructors m ->
+  Destructors m
 insertDestructor action key destructors =
-  let destructor = Destructor { isRegistered = True, .. }
-  in  insert key destructor destructors
+  let destructor = Destructor {isRegistered = True, ..}
+   in insert key destructor destructors
 
-unregisterAll
-  :: Monad m
-  => HandlingStateT m ()
+unregisterAll ::
+  Monad m =>
+  HandlingStateT m ()
 unregisterAll = do
-  HandlingState { .. } <- get
-  let newDestructors = IntMap.map (\destructor -> destructor { isRegistered = False }) destructors
-  put HandlingState { destructors = newDestructors, .. }
+  HandlingState {..} <- get
+  let newDestructors = IntMap.map (\destructor -> destructor {isRegistered = False}) destructors
+  put HandlingState {destructors = newDestructors, ..}
 
-destroyUnregistered
-  :: Monad m
-  => HandlingStateT m ()
+destroyUnregistered ::
+  Monad m =>
+  HandlingStateT m ()
 destroyUnregistered = do
-  HandlingState { .. } <- get
-  let
-      (registered, unregistered) = partition isRegistered destructors
+  HandlingState {..} <- get
+  let (registered, unregistered) = partition isRegistered destructors
   traverse_ (lift . action) unregistered
-  put HandlingState { destructors = registered, .. }
+  put HandlingState {destructors = registered, ..}
 
 -- * 'Data' instances
+
 dataTypeDestructor :: DataType
-dataTypeDestructor = mkDataType "Destructor" [ destructorConstr ]
+dataTypeDestructor = mkDataType "Destructor" [destructorConstr]
 
 destructorConstr :: Constr
 destructorConstr = mkConstr dataTypeDestructor "Destructor" [] Prefix
 
 instance Typeable m => Data (Destructor m) where
   dataTypeOf _ = dataTypeDestructor
-  toConstr Destructor { .. } = destructorConstr
+  toConstr Destructor {..} = destructorConstr
   gunfold _ _ = error "Destructor.gunfold"

--- a/essence-of-live-coding/src/LiveCoding/LiveProgram/Except.hs
+++ b/essence-of-live-coding/src/LiveCoding/LiveProgram/Except.hs
@@ -1,113 +1,108 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{- | Live programs in the @'ExceptT' e m@ monad can stop execution by throwing an exception @e@.
+{-# LANGUAGE RecordWildCards #-}
 
-Handling these exceptions is done by realising that live programs in fact form a monad in the exception type.
-The interface is analogous to 'CellExcept'.
--}
+-- | Live programs in the @'ExceptT' e m@ monad can stop execution by throwing an exception @e@.
+--
+-- Handling these exceptions is done by realising that live programs in fact form a monad in the exception type.
+-- The interface is analogous to 'CellExcept'.
 module LiveCoding.LiveProgram.Except where
 
 -- base
-import Control.Monad (liftM, ap)
-import Data.Data
-import Data.Void (Void)
-
+import Control.Monad (ap, liftM)
 -- transformers
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Reader
-
+import Data.Data
+import Data.Void (Void)
 -- essence-of-live-coding
-import LiveCoding.Cell (hoistCell, toLiveCell, liveCell, constM)
-import LiveCoding.CellExcept (CellExcept, runCellExcept, once_)
+import LiveCoding.Cell (constM, hoistCell, liveCell, toLiveCell)
+import LiveCoding.CellExcept (CellExcept, once_, runCellExcept)
+import qualified LiveCoding.CellExcept as CellExcept
 import LiveCoding.Exceptions.Finite (Finite)
 import LiveCoding.Forever
 import LiveCoding.LiveProgram
-import qualified LiveCoding.CellExcept as CellExcept
 
-{- | A live program that can throw an exception.
-
-* @m@: The monad in which the live program operates.
-* @e@: The type of exceptions the live program can eventually throw.
-
-'LiveProgramExcept' is a monad in the exception type.
-This means that it is possible to chain several live programs,
-where later programs can handle the exceptions thrown by the earlier ones.
-'return' plays the role of directly throwing an exception.
-'(>>=)' lets a handler decide which program to handle the exception with.
-
-The interface is the basically the same as 'CellExcept',
-and it is in fact a newtype around it.
--}
+-- | A live program that can throw an exception.
+--
+-- * @m@: The monad in which the live program operates.
+-- * @e@: The type of exceptions the live program can eventually throw.
+--
+-- 'LiveProgramExcept' is a monad in the exception type.
+-- This means that it is possible to chain several live programs,
+-- where later programs can handle the exceptions thrown by the earlier ones.
+-- 'return' plays the role of directly throwing an exception.
+-- '(>>=)' lets a handler decide which program to handle the exception with.
+--
+-- The interface is the basically the same as 'CellExcept',
+-- and it is in fact a newtype around it.
 newtype LiveProgramExcept m e = LiveProgramExcept
-  { unLiveProgramExcept :: CellExcept () () m e }
+  {unLiveProgramExcept :: CellExcept () () m e}
   deriving (Functor, Applicative, Monad)
 
 -- | Execute a 'LiveProgramExcept', throwing its exceptions in the 'ExceptT' monad.
-runLiveProgramExcept
-  :: Monad m
-  => LiveProgramExcept m e
-  -> LiveProgram (ExceptT e m)
-runLiveProgramExcept LiveProgramExcept { .. } = liveCell $ runCellExcept unLiveProgramExcept
+runLiveProgramExcept ::
+  Monad m =>
+  LiveProgramExcept m e ->
+  LiveProgram (ExceptT e m)
+runLiveProgramExcept LiveProgramExcept {..} = liveCell $ runCellExcept unLiveProgramExcept
 
-{- | Lift a 'LiveProgram' into the 'LiveProgramExcept' monad.
-
-Similar to 'LiveProgram.CellExcept.try'.
-This will execute the live program until it throws an exception.
--}
-try
-  :: (Data e, Finite e, Functor m)
-  => LiveProgram (ExceptT e m)
-  -> LiveProgramExcept m e
+-- | Lift a 'LiveProgram' into the 'LiveProgramExcept' monad.
+--
+-- Similar to 'LiveProgram.CellExcept.try'.
+-- This will execute the live program until it throws an exception.
+try ::
+  (Data e, Finite e, Functor m) =>
+  LiveProgram (ExceptT e m) ->
+  LiveProgramExcept m e
 try = LiveProgramExcept . CellExcept.try . toLiveCell
 
-{- | Safely convert to 'LiveProgram's.
-
-If the type of possible exceptions is empty,
-no exceptions can be thrown,
-and thus we can safely assume that it is a 'LiveProgram' in @m@.
--}
-safely
-  :: Monad m
-  => LiveProgramExcept m Void
-  -> LiveProgram m
+-- | Safely convert to 'LiveProgram's.
+--
+-- If the type of possible exceptions is empty,
+-- no exceptions can be thrown,
+-- and thus we can safely assume that it is a 'LiveProgram' in @m@.
+safely ::
+  Monad m =>
+  LiveProgramExcept m Void ->
+  LiveProgram m
 safely = liveCell . CellExcept.safely . unLiveProgramExcept
 
-{- | Run a 'LiveProgram' as a 'LiveProgramExcept'.
-
-This is always safe in the sense that it has no exceptions.
--}
-safe
-  :: Monad m
-  => LiveProgram m
-  -> LiveProgramExcept m Void
+-- | Run a 'LiveProgram' as a 'LiveProgramExcept'.
+--
+-- This is always safe in the sense that it has no exceptions.
+safe ::
+  Monad m =>
+  LiveProgram m ->
+  LiveProgramExcept m Void
 safe = LiveProgramExcept . CellExcept.safe . toLiveCell
 
 -- | Run a monadic action and immediately raise its result as an exception.
 once :: (Monad m, Data e, Finite e) => m e -> LiveProgramExcept m e
 once = LiveProgramExcept . once_
 
-{- | Run a 'LiveProgramExcept' in a loop.
-
-In the additional 'ReaderT e' context,
-you can read the last thrown exception.
-(For the first iteration, 'e' is set to the first argument to 'foreverELiveProgram'.)
-
-This way, you can create an infinite loop,
-with the exception as the loop variable.
--}
-foreverELiveProgram
-  :: (Data e, Monad m)
-  => e -- ^ The loop initialisation
-  -> LiveProgramExcept (ReaderT e m) e -- ^ The live program to execute indefinitely
-  -> LiveProgram                  m
-foreverELiveProgram e LiveProgramExcept { .. } = liveCell $ foreverE e $ hoistCell commute $ runCellExcept unLiveProgramExcept
+-- | Run a 'LiveProgramExcept' in a loop.
+--
+-- In the additional 'ReaderT e' context,
+-- you can read the last thrown exception.
+-- (For the first iteration, 'e' is set to the first argument to 'foreverELiveProgram'.)
+--
+-- This way, you can create an infinite loop,
+-- with the exception as the loop variable.
+foreverELiveProgram ::
+  (Data e, Monad m) =>
+  -- | The loop initialisation
+  e ->
+  -- | The live program to execute indefinitely
+  LiveProgramExcept (ReaderT e m) e ->
+  LiveProgram m
+foreverELiveProgram e LiveProgramExcept {..} = liveCell $ foreverE e $ hoistCell commute $ runCellExcept unLiveProgramExcept
   where
     commute :: ExceptT e (ReaderT r m) a -> ReaderT r (ExceptT e m) a
     commute action = ReaderT $ ExceptT . runReaderT (runExceptT action)
 
 -- | Run a 'LiveProgramExcept' in a loop, discarding the exception.
-foreverCLiveProgram
-  :: (Data e, Monad m)
-  => LiveProgramExcept m e
-  -> LiveProgram       m
-foreverCLiveProgram LiveProgramExcept { .. } = liveCell $ foreverC $ runCellExcept unLiveProgramExcept
+foreverCLiveProgram ::
+  (Data e, Monad m) =>
+  LiveProgramExcept m e ->
+  LiveProgram m
+foreverCLiveProgram LiveProgramExcept {..} = liveCell $ foreverC $ runCellExcept unLiveProgramExcept

--- a/essence-of-live-coding/src/LiveCoding/LiveProgram/Monad/Trans.hs
+++ b/essence-of-live-coding/src/LiveCoding/LiveProgram/Monad/Trans.hs
@@ -1,29 +1,31 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RecordWildCards #-}
+
 module LiveCoding.LiveProgram.Monad.Trans where
 
 -- base
-import Data.Data
 
 -- transformers
 import Control.Monad.Trans.State.Strict
-
+import Data.Data
 -- essence-of-live-coding
-import LiveCoding.LiveProgram
+
 import LiveCoding.Cell.Monad.Trans
+import LiveCoding.LiveProgram
 
 -- | Remove a stateful effect from the monad stack by supplying the initial state.
 --   This state then becomes part of the internal live program state,
 --   and is subject to migration as any other state.
 --   Live programs are automatically migrated to and from applications of 'runStateL'.
-runStateL
-  :: (Data stateT, Monad m)
-  => LiveProgram (StateT stateT m)
-  ->                     stateT
-  -> LiveProgram                m
-runStateL LiveProgram { .. } stateT = LiveProgram
-  { liveState = State { stateInternal = liveState, .. }
-  , liveStep = \State { .. } -> do
-      (stateInternal, stateT) <- runStateT (liveStep stateInternal) stateT
-      return State { .. }
-  }
+runStateL ::
+  (Data stateT, Monad m) =>
+  LiveProgram (StateT stateT m) ->
+  stateT ->
+  LiveProgram m
+runStateL LiveProgram {..} stateT =
+  LiveProgram
+    { liveState = State {stateInternal = liveState, ..},
+      liveStep = \State {..} -> do
+        (stateInternal, stateT) <- runStateT (liveStep stateInternal) stateT
+        return State {..}
+    }

--- a/essence-of-live-coding/src/LiveCoding/Migrate/Cell.hs
+++ b/essence-of-live-coding/src/LiveCoding/Migrate/Cell.hs
@@ -1,19 +1,21 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+
 module LiveCoding.Migrate.Cell where
 
 -- base
-import Data.Data
 
 -- syb
-import Data.Generics.Aliases
 
 -- essence-of-live-coding
+
+import Control.Applicative (Alternative ((<|>)))
+import Data.Data
+import Data.Generics.Aliases
 import LiveCoding.Cell
 import LiveCoding.Cell.Feedback
 import LiveCoding.Exceptions
 import LiveCoding.Migrate.Migration
-import Control.Applicative (Alternative((<|>)))
 
 -- * Migrations to and from pairs
 
@@ -23,32 +25,32 @@ import Control.Applicative (Alternative((<|>)))
 --   such as tuples, but customisable to your own products.
 --   You need to pass it the equivalents of 'fst', 'snd', and '(,)'.
 --   Tries to migrate the value into the first element, then into the second.
-maybeMigrateToPair
-  :: (Typeable a, Typeable b, Typeable c)
-  => (t a b -> a)
-  -- ^ The accessor of the first element
-  -> (t a b -> b)
-  -- ^ The accessor of the second element
-  -> (a -> b -> t a b)
-  -- ^ The constructor
-  -> t a b
-  -- ^ The pair
-  -> c
-  -- ^ The new value for the first or second element
-  -> Maybe (t a b)
+maybeMigrateToPair ::
+  (Typeable a, Typeable b, Typeable c) =>
+  -- | The accessor of the first element
+  (t a b -> a) ->
+  -- | The accessor of the second element
+  (t a b -> b) ->
+  -- | The constructor
+  (a -> b -> t a b) ->
+  -- | The pair
+  t a b ->
+  -- | The new value for the first or second element
+  c ->
+  Maybe (t a b)
 maybeMigrateToPair fst snd cons pair c = do
   flip cons (snd pair) <$> cast c <|> cons (fst pair) <$> cast c
 
 -- | Like 'maybeMigrateToPair', but in the other direction.
 --   Again, it is biased with respect to the first element of the pair.
-maybeMigrateFromPair
-  :: (Typeable a, Typeable b, Typeable c)
-  => (t a b -> a)
-  -- ^ The accessor of the first element
-  -> (t a b -> b)
-  -- ^ The accessor of the second element
-  -> t a b
-  -> Maybe c
+maybeMigrateFromPair ::
+  (Typeable a, Typeable b, Typeable c) =>
+  -- | The accessor of the first element
+  (t a b -> a) ->
+  -- | The accessor of the second element
+  (t a b -> b) ->
+  t a b ->
+  Maybe c
 maybeMigrateFromPair fst snd pair = cast (fst pair) <|> cast (snd pair)
 
 -- ** Migrations involving sequential compositions of cells
@@ -57,16 +59,15 @@ maybeMigrateFromPair fst snd pair = cast (fst pair) <|> cast (snd pair)
 migrationToComposition :: Migration
 migrationToComposition = migrationTo2 $ maybeMigrateToPair state1 state2 Composition
 
-
 -- | Migrate @cell1 >>> cell2@ to @cell1@, and if this fails, to @cell2@.
 migrationFromComposition :: Migration
 migrationFromComposition = constMigrationFrom2 $ maybeMigrateFromPair state1 state2
 
 -- | Combines all migrations related to composition, favouring migration to compositions.
 migrationComposition :: Migration
-migrationComposition
-  =  migrationToComposition
-  <> migrationFromComposition
+migrationComposition =
+  migrationToComposition
+    <> migrationFromComposition
 
 -- ** Migrations involving parallel compositions of cells
 
@@ -80,9 +81,9 @@ migrationFromParallel = constMigrationFrom2 $ maybeMigrateFromPair stateP1 state
 
 -- | Combines all migrations related to parallel composition, favouring migration to parallel composition.
 migrationParallel :: Migration
-migrationParallel
-  =  migrationToParallel
-  <> migrationFromParallel
+migrationParallel =
+  migrationToParallel
+    <> migrationFromParallel
 
 -- ** Migration involving 'ArrowChoice'
 
@@ -96,9 +97,9 @@ migrationFromChoice = constMigrationFrom2 $ maybeMigrateFromPair choiceLeft choi
 
 -- | Combines all migrations related to choice, favouring migration to choice.
 migrationChoice :: Migration
-migrationChoice
-  =  migrationToChoice
-  <> migrationFromChoice
+migrationChoice =
+  migrationToChoice
+    <> migrationFromChoice
 
 -- ** Feedback
 
@@ -116,11 +117,11 @@ migrationFeedback = migrationToFeedback <> migrationFromFeedback
 
 -- * Control flow
 
-maybeMigrateToExceptState
-  :: (Typeable state, Typeable state')
-  => ExceptState state e
-  ->             state'
-  -> Maybe (ExceptState state e)
+maybeMigrateToExceptState ::
+  (Typeable state, Typeable state') =>
+  ExceptState state e ->
+  state' ->
+  Maybe (ExceptState state e)
 maybeMigrateToExceptState (NotThrown _) state = NotThrown <$> cast state
 maybeMigrateToExceptState (Exception e) _ = Just $ Exception e
 
@@ -128,10 +129,10 @@ maybeMigrateToExceptState (Exception e) _ = Just $ Exception e
 migrationToExceptState :: Migration
 migrationToExceptState = migrationTo2 maybeMigrateToExceptState
 
-maybeMigrateFromExceptState
-  :: (Typeable state, Typeable state')
-  => ExceptState state e
-  -> Maybe       state'
+maybeMigrateFromExceptState ::
+  (Typeable state, Typeable state') =>
+  ExceptState state e ->
+  Maybe state'
 maybeMigrateFromExceptState (NotThrown state) = cast state
 maybeMigrateFromExceptState (Exception e) = Nothing
 
@@ -147,9 +148,9 @@ migrationExceptState = migrationToExceptState <> migrationFromExceptState
 
 -- | Combines all 'Cell'-related migrations.
 migrationCell :: Migration
-migrationCell
-  =  migrationComposition
-  <> migrationParallel
-  <> migrationChoice
-  <> migrationExceptState
-  <> migrationFeedback
+migrationCell =
+  migrationComposition
+    <> migrationParallel
+    <> migrationChoice
+    <> migrationExceptState
+    <> migrationFeedback

--- a/essence-of-live-coding/src/LiveCoding/Migrate/Debugger.hs
+++ b/essence-of-live-coding/src/LiveCoding/Migrate/Debugger.hs
@@ -1,32 +1,32 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+
 module LiveCoding.Migrate.Debugger where
 
 -- base
 import Data.Data
-
 -- essence-of-live-coding
 import LiveCoding.Debugger
 import LiveCoding.Migrate.Migration
 
-maybeMigrateToDebugging
-  :: (Typeable state', Typeable state)
-  => Debugging dbgState state
-  -> state'
-  -> Maybe (Debugging dbgState state)
-maybeMigrateToDebugging Debugging { dbgState } state' = do
+maybeMigrateToDebugging ::
+  (Typeable state', Typeable state) =>
+  Debugging dbgState state ->
+  state' ->
+  Maybe (Debugging dbgState state)
+maybeMigrateToDebugging Debugging {dbgState} state' = do
   state <- cast state'
-  return Debugging { .. }
+  return Debugging {..}
 
 -- | Tries to cast the current state into the joint state of debugger and program.
 migrationToDebugging :: Migration
 migrationToDebugging = migrationTo2 maybeMigrateToDebugging
 
-maybeMigrateFromDebugging
-  :: (Typeable state', Typeable state)
-  => Debugging dbgState state
-  -> Maybe              state'
-maybeMigrateFromDebugging Debugging { state } = cast state
+maybeMigrateFromDebugging ::
+  (Typeable state', Typeable state) =>
+  Debugging dbgState state ->
+  Maybe state'
+maybeMigrateFromDebugging Debugging {state} = cast state
 
 -- | Try to extract a state from the current joint state of debugger and program.
 migrationFromDebugging :: Migration

--- a/essence-of-live-coding/src/LiveCoding/Migrate/Migration.hs
+++ b/essence-of-live-coding/src/LiveCoding/Migrate/Migration.hs
@@ -5,28 +5,30 @@ module LiveCoding.Migrate.Migration where
 -- base
 import Control.Monad (guard)
 import Data.Data
-import Data.Maybe (fromMaybe)
-import Data.Monoid
-
 -- syb
 import Data.Generics.Aliases
 import Data.Generics.Schemes (glength)
+import Data.Maybe (fromMaybe)
+import Data.Monoid
 
 data Migration = Migration
-  { runMigration :: forall a b . (Data a, Data b) => a -> b -> Maybe a }
+  {runMigration :: forall a b. (Data a, Data b) => a -> b -> Maybe a}
 
 -- | Run a migration and insert the new initial state in case of failure.
-runSafeMigration
-  :: (Data a, Data b)
-  => Migration
-  -> a -> b -> a
+runSafeMigration ::
+  (Data a, Data b) =>
+  Migration ->
+  a ->
+  b ->
+  a
 runSafeMigration migration a b = fromMaybe a $ runMigration migration a b
 
 -- | If both migrations would succeed, the result from the first is used.
 instance Semigroup Migration where
-  migration1 <> migration2 = Migration $ \a b -> getFirst
-    $  (First $ runMigration migration1 a b)
-    <> (First $ runMigration migration2 a b)
+  migration1 <> migration2 = Migration $ \a b ->
+    getFirst $
+      (First $ runMigration migration1 a b)
+        <> (First $ runMigration migration2 a b)
 
 instance Monoid Migration where
   mempty = Migration $ const $ const Nothing
@@ -48,26 +50,26 @@ newtypeMigration = Migration $ \a b -> do
 -- | If you have a specific type that you would like to be migrated to a specific other type,
 --   you can create a migration for this.
 --   For example: @userMigration (toInteger :: Int -> Integer)@
-userMigration
-  :: (Typeable c, Typeable d)
-  => (c -> d)
-  -> Migration
+userMigration ::
+  (Typeable c, Typeable d) =>
+  (c -> d) ->
+  Migration
 userMigration specific = Migration $ \_a b -> cast =<< specific <$> cast b
 
-migrationTo2
-  :: Typeable t
-  => (forall a b c . (Typeable a, Typeable b, Typeable c) => t b c -> a -> Maybe (t b c))
-  -> Migration
+migrationTo2 ::
+  Typeable t =>
+  (forall a b c. (Typeable a, Typeable b, Typeable c) => t b c -> a -> Maybe (t b c)) ->
+  Migration
 migrationTo2 f = Migration $ \t a -> ext2M (const Nothing) (flip f a) t
 
-constMigrationFrom2
-  :: Typeable t
-  => (forall a b c . (Typeable a, Typeable b, Typeable c) => t b c -> Maybe a)
-  -> Migration
+constMigrationFrom2 ::
+  Typeable t =>
+  (forall a b c. (Typeable a, Typeable b, Typeable c) => t b c -> Maybe a) ->
+  Migration
 constMigrationFrom2 f = Migration $ \_ t -> ext2Q (const Nothing) f t
 
-migrationTo1
-  :: Typeable t
-  => (forall a b . (Typeable a, Typeable b) => t b -> a -> Maybe (t b))
-  -> Migration
+migrationTo1 ::
+  Typeable t =>
+  (forall a b. (Typeable a, Typeable b) => t b -> a -> Maybe (t b)) ->
+  Migration
 migrationTo1 f = Migration $ \t a -> ext1M (const Nothing) (flip f a) t

--- a/essence-of-live-coding/src/LiveCoding/Migrate/Monad/Trans.hs
+++ b/essence-of-live-coding/src/LiveCoding/Migrate/Monad/Trans.hs
@@ -1,33 +1,33 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+
 module LiveCoding.Migrate.Monad.Trans where
 
 -- base
 import Data.Data
-
 -- essence-of-live-coding
 import LiveCoding.Cell.Monad.Trans
 import LiveCoding.Migrate.Migration
 
-maybeMigrateToState
-  :: (Typeable stateInternal', Typeable stateInternal)
-  => State stateT stateInternal
-  -> stateInternal'
-  -> Maybe (State stateT stateInternal)
-maybeMigrateToState State { stateT } stateInternal' = do
+maybeMigrateToState ::
+  (Typeable stateInternal', Typeable stateInternal) =>
+  State stateT stateInternal ->
+  stateInternal' ->
+  Maybe (State stateT stateInternal)
+maybeMigrateToState State {stateT} stateInternal' = do
   stateInternal <- cast stateInternal'
-  return State { .. }
+  return State {..}
 
 -- | Tries to cast the current state into the joint state of a program
 --   where a state effect has been absorbed into the internal state with 'runStateL' or 'runStateC'.
 migrationToState :: Migration
 migrationToState = migrationTo2 maybeMigrateToState
 
-maybeMigrateFromState
-  :: (Typeable stateInternal', Typeable stateInternal)
-  => State stateT stateInternal
-  -> Maybe              stateInternal'
-maybeMigrateFromState State { stateInternal } = cast stateInternal
+maybeMigrateFromState ::
+  (Typeable stateInternal', Typeable stateInternal) =>
+  State stateT stateInternal ->
+  Maybe stateInternal'
+maybeMigrateFromState State {stateInternal} = cast stateInternal
 
 -- | Try to extract a state from the current joint state of a program wrapped with 'runStateL' or 'runStateC'.
 migrationFromState :: Migration

--- a/essence-of-live-coding/src/LiveCoding/Migrate/NoMigration.hs
+++ b/essence-of-live-coding/src/LiveCoding/Migrate/NoMigration.hs
@@ -2,47 +2,47 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE RecordWildCards #-}
 
-{-|
-Module      : LiveCoding.Migrate.NoMigration
-Description : Mechanism to save state in a Cell without requiring a Data instance.
-
-If a data type is wrapped in 'NoMigration' then it can be used as the state of a 'Cell'
-without requiring it to have a 'Data' instance. The consequence is that if the type has changed
-in between a livereload, then the previous saved value will be discarded, and no migration attempt
-will happen.
-
-'LiveCoding' does not export 'delay' and 'changes' from this module. These functions should be
-used with a qualified import.
--}
+-- |
+-- Module      : LiveCoding.Migrate.NoMigration
+-- Description : Mechanism to save state in a Cell without requiring a Data instance.
+--
+-- If a data type is wrapped in 'NoMigration' then it can be used as the state of a 'Cell'
+-- without requiring it to have a 'Data' instance. The consequence is that if the type has changed
+-- in between a livereload, then the previous saved value will be discarded, and no migration attempt
+-- will happen.
+--
+-- 'LiveCoding' does not export 'delay' and 'changes' from this module. These functions should be
+-- used with a qualified import.
 module LiveCoding.Migrate.NoMigration where
 
 -- base
-import Data.Data
-    ( Data(dataTypeOf, gunfold, toConstr),
-      Typeable,
-      mkConstr,
-      mkDataType,
-      Constr,
-      DataType,
-      Fixity(Prefix) )
-import Control.Arrow ( Arrow(arr, second), returnA, (>>>) )
-import Control.Monad (guard)
 
+import Control.Arrow (Arrow (arr, second), returnA, (>>>))
+import Control.Monad (guard)
+import Data.Data
+  ( Constr,
+    Data (dataTypeOf, gunfold, toConstr),
+    DataType,
+    Fixity (Prefix),
+    Typeable,
+    mkConstr,
+    mkDataType,
+  )
 -- essence-of-live-coding
 import LiveCoding.Cell
-import LiveCoding.Cell.Monad ( hoistCellKleisli )
 import qualified LiveCoding.Cell.Feedback as Feedback
+import LiveCoding.Cell.Monad (hoistCellKleisli)
 
 -- * 'NoMigration' data type and 'Data' instance.
 
 -- | Isomorphic to @'Maybe' a@ but has a different 'Data' instance. The 'Data' instance for @'NoMigration' a@ doesn't require a 'Data' instance for @a@.
--- 
+--
 -- If a data type is wrapped in 'NoMigration' then it can be used as the state of a 'Cell'
 -- without requiring it to have a 'Data' instance. The consequence is that if the type has changed
 -- in between a livereload, then the previous saved value will be discarded, and no migration attempt
 -- will happen.
 data NoMigration a = Initialized a | Uninitialized
-    deriving (Show, Eq, Functor, Foldable, Traversable)
+  deriving (Show, Eq, Functor, Foldable, Traversable)
 
 fromNoMigration :: a -> NoMigration a -> a
 fromNoMigration _ (Initialized a) = a
@@ -57,13 +57,12 @@ initializedConstr = mkConstr dataTypeNoMigration "Initialized" [] Prefix
 uninitializedConstr :: Constr
 uninitializedConstr = mkConstr dataTypeNoMigration "Uninitialized" [] Prefix
 
--- |The Data instance for @'NoMigration' a@ doesn't require a 'Data' instance for @a@.
-instance (Typeable a) => Data (NoMigration a)
-  where
-    dataTypeOf _ = dataTypeNoMigration
-    toConstr (Initialized _) = initializedConstr
-    toConstr Uninitialized = uninitializedConstr
-    gunfold _cons nil _ = nil Uninitialized
+-- | The Data instance for @'NoMigration' a@ doesn't require a 'Data' instance for @a@.
+instance (Typeable a) => Data (NoMigration a) where
+  dataTypeOf _ = dataTypeNoMigration
+  toConstr (Initialized _) = initializedConstr
+  toConstr Uninitialized = uninitializedConstr
+  gunfold _cons nil _ = nil Uninitialized
 
 -- * Utility functions which internally use 'NoMigration'.
 
@@ -77,28 +76,30 @@ delay a = arr Initialized >>> Feedback.delay Uninitialized >>> arr (fromNoMigrat
 changes :: (Typeable a, Eq a, Monad m) => Cell m a (Maybe a)
 changes = proc a -> do
   aLast <- delay Nothing -< Just a
-  returnA -< do
+  returnA
+    -< do
       aLast' <- aLast
       guard $ a /= aLast'
       return a
 
--- | Caching version of 'arrM'. 
+-- | Caching version of 'arrM'.
 --
 --   Only runs the computation in @m@ when the input value
 --   changes. Meanwhile it keeps outputing the last outputted value. Also runs the computation
 --   on the first tick. Does not require 'Data' instance. On `:livereload` will run action again on
 --   first tick.
 arrChangesM :: (Monad m, Typeable a, Typeable b, Eq a) => (a -> m b) -> Cell m a b
-arrChangesM f = Cell { cellState = Uninitialized, ..}
+arrChangesM f = Cell {cellState = Uninitialized, ..}
   where
-    cellStep Uninitialized        a = h a
-    cellStep (Initialized (a',b)) a = if a == a'
-      then return (b, Initialized (a, b))
-      else h a
-    h a = (\b' -> (b', Initialized (a, b') )) <$> f a
+    cellStep Uninitialized a = h a
+    cellStep (Initialized (a', b)) a =
+      if a == a'
+        then return (b, Initialized (a, b))
+        else h a
+    h a = (\b' -> (b', Initialized (a, b'))) <$> f a
 
 cellNoMigration :: (Typeable s, Functor m) => s -> (s -> a -> m (b, s)) -> Cell m a b
-cellNoMigration state step = Cell { cellState = Uninitialized, ..}
+cellNoMigration state step = Cell {cellState = Uninitialized, ..}
   where
     cellStep Uninitialized a = second Initialized <$> step state a
     cellStep (Initialized s) a = second Initialized <$> step s a

--- a/essence-of-live-coding/src/LiveCoding/RuntimeIO/Launch.hs
+++ b/essence-of-live-coding/src/LiveCoding/RuntimeIO/Launch.hs
@@ -1,35 +1,35 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
 module LiveCoding.RuntimeIO.Launch where
 
 -- base
 import Control.Concurrent
 import Control.Monad
-import Data.Data
-
 -- transformers
-import Control.Monad.Trans.State.Strict
-import Control.Monad.Trans.Except
 
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.State.Strict
+import Data.Data
 -- essence-of-live-coding
+
+import LiveCoding.Cell.Monad.Trans
 import LiveCoding.Debugger
+import LiveCoding.Exceptions.Finite (Finite)
 import LiveCoding.Handle
+import LiveCoding.HandlingState
 import LiveCoding.LiveProgram
 import LiveCoding.LiveProgram.Except
 import LiveCoding.LiveProgram.HotCodeSwap
-import LiveCoding.Cell.Monad.Trans
-import LiveCoding.Exceptions.Finite (Finite)
-import LiveCoding.HandlingState
 
-{- | Monads in which live programs can be launched in 'IO',
-for example when you have special effects that have to be handled on every reload.
-
-The only thing necessary is to transform the 'LiveProgram'
-into one in the 'IO' monad, and the rest is taken care of in the framework.
--}
+-- | Monads in which live programs can be launched in 'IO',
+-- for example when you have special effects that have to be handled on every reload.
+--
+-- The only thing necessary is to transform the 'LiveProgram'
+-- into one in the 'IO' monad, and the rest is taken care of in the framework.
 class Monad m => Launchable m where
   runIO :: LiveProgram m -> LiveProgram IO
 
@@ -44,85 +44,83 @@ instance (Typeable m, Launchable m) => Launchable (HandlingStateT m) where
 instance (Data e, Finite e, Launchable m) => Launchable (ExceptT e m) where
   runIO liveProgram = runIO $ foreverCLiveProgram $ try liveProgram
 
-{- | The standard top level @main@ for a live program.
-
-Typically, you will define a top level 'LiveProgram' in some monad like @'HandlingStateT' 'IO'@,
-and then add these two lines of boiler plate:
-
-@
-main :: IO ()
-main = liveMain liveProgram
-@
--}
-liveMain
-  :: Launchable m
-  => LiveProgram m
-  -> IO ()
+-- | The standard top level @main@ for a live program.
+--
+-- Typically, you will define a top level 'LiveProgram' in some monad like @'HandlingStateT' 'IO'@,
+-- and then add these two lines of boiler plate:
+--
+-- @
+-- main :: IO ()
+-- main = liveMain liveProgram
+-- @
+liveMain ::
+  Launchable m =>
+  LiveProgram m ->
+  IO ()
 liveMain = foreground . runIO
 
 -- | Launch a 'LiveProgram' in the foreground thread (blocking).
 foreground :: Monad m => LiveProgram m -> m ()
-foreground liveProgram
-  =   stepProgram liveProgram
-  >>= foreground
+foreground liveProgram =
+  stepProgram liveProgram
+    >>= foreground
 
 -- | A launched 'LiveProgram' and the thread in which it is running.
 data LaunchedProgram (m :: * -> *) = LaunchedProgram
-  { programVar :: MVar (LiveProgram IO)
-  , threadId   :: ThreadId
+  { programVar :: MVar (LiveProgram IO),
+    threadId :: ThreadId
   }
 
-{- | Launch a 'LiveProgram' in a separate thread.
-
-The 'MVar' can be used to 'update' the program while automatically migrating it.
-The 'ThreadId' represents the thread where the program runs in.
-You're advised not to kill it directly, but to run 'stop' instead.
--}
-launch
-  :: Launchable m
-  => LiveProgram m
-  -> IO (LaunchedProgram m)
+-- | Launch a 'LiveProgram' in a separate thread.
+--
+-- The 'MVar' can be used to 'update' the program while automatically migrating it.
+-- The 'ThreadId' represents the thread where the program runs in.
+-- You're advised not to kill it directly, but to run 'stop' instead.
+launch ::
+  Launchable m =>
+  LiveProgram m ->
+  IO (LaunchedProgram m)
 launch liveProg = do
   programVar <- newMVar $ runIO liveProg
   threadId <- forkIO $ background programVar
-  return LaunchedProgram { .. }
+  return LaunchedProgram {..}
 
 -- | Migrate (using 'hotCodeSwap') the 'LiveProgram' to a new version.
-update
-  :: Launchable m
-  => LaunchedProgram m
-  -> LiveProgram     m
-  -> IO ()
-update LaunchedProgram { .. } newProg = modifyMVarMasked_ programVar
-  $ return . hotCodeSwap (runIO newProg)
+update ::
+  Launchable m =>
+  LaunchedProgram m ->
+  LiveProgram m ->
+  IO ()
+update LaunchedProgram {..} newProg =
+  modifyMVarMasked_ programVar $
+    return . hotCodeSwap (runIO newProg)
 
-{- | Stops a thread where a 'LiveProgram' is being executed.
-
-Before the thread is killed, an empty program (in the monad @m@) is first inserted and stepped.
-This can be used to call cleanup actions encoded in the monad,
-such as 'HandlingStateT'.
--}
-stop
-  :: Launchable m
-  => LaunchedProgram m
-  -> IO ()
-stop launchedProgram@LaunchedProgram { .. } = do
+-- | Stops a thread where a 'LiveProgram' is being executed.
+--
+-- Before the thread is killed, an empty program (in the monad @m@) is first inserted and stepped.
+-- This can be used to call cleanup actions encoded in the monad,
+-- such as 'HandlingStateT'.
+stop ::
+  Launchable m =>
+  LaunchedProgram m ->
+  IO ()
+stop launchedProgram@LaunchedProgram {..} = do
   update launchedProgram mempty
   stepLaunchedProgram launchedProgram
   killThread threadId
 
 -- | Launch a 'LiveProgram', but first attach a debugger to it.
-launchWithDebugger
-  :: (Monad m, Launchable m)
-  => LiveProgram m
-  -> Debugger m
-  -> IO (LaunchedProgram m)
+launchWithDebugger ::
+  (Monad m, Launchable m) =>
+  LiveProgram m ->
+  Debugger m ->
+  IO (LaunchedProgram m)
 launchWithDebugger liveProg debugger = launch $ liveProg `withDebugger` debugger
 
 -- | This is the background task executed by 'launch'.
 background :: MVar (LiveProgram IO) -> IO ()
 background var = forever $ do
-  liveProg  <- takeMVar var
+  liveProg <- takeMVar var
   liveProg' <- stepProgram liveProg
   putMVar var liveProg'
 
@@ -130,11 +128,11 @@ background var = forever $ do
 stepProgram :: Monad m => LiveProgram m -> m (LiveProgram m)
 stepProgram LiveProgram {..} = do
   liveState' <- liveStep liveState
-  return LiveProgram { liveState = liveState', .. }
+  return LiveProgram {liveState = liveState', ..}
 
 -- | Advance a launched 'LiveProgram' by a single step and store the result.
-stepLaunchedProgram
-  :: (Monad m, Launchable m)
-  => LaunchedProgram m
-  -> IO ()
-stepLaunchedProgram LaunchedProgram { .. } = modifyMVarMasked_ programVar stepProgram
+stepLaunchedProgram ::
+  (Monad m, Launchable m) =>
+  LaunchedProgram m ->
+  IO ()
+stepLaunchedProgram LaunchedProgram {..} = modifyMVarMasked_ programVar stepProgram

--- a/essence-of-live-coding/test/Cell.hs
+++ b/essence-of-live-coding/test/Cell.hs
@@ -1,36 +1,39 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+
 module Cell where
 
 -- base
-import Prelude hiding (id)
-import Control.Category
-import Data.Functor.Identity
 
 -- transformers
-import Control.Monad.Trans.Identity
 
 -- test-framework
-import Test.Framework
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2
 
 -- QuickCheck
-import Test.QuickCheck
 
 -- essence-of-live-coding
-import LiveCoding
 
-import qualified Cell.Util
 import qualified Cell.Monad.Trans
+import qualified Cell.Util
+import Control.Category
+import Control.Monad.Trans.Identity
+import Data.Functor.Identity
+import LiveCoding
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2
+import Test.QuickCheck
+import Prelude hiding (id)
 
-test = testGroup "Cell"
-  [ testProperty "steps produces outputs"
-    $ \(inputs :: [Int]) -> inputs === fst (runIdentity $ steps (id :: Cell Identity Int Int) inputs)
-  , testProperty "sumC works as expected"
-    $ forAll (vector 100) $ \(inputs :: [Int]) ->
-        sum (init inputs) ===
-          last (fst (runIdentity $ steps (sumC :: Cell Identity Int Int) inputs))
-  , Cell.Util.test
-  , Cell.Monad.Trans.test
-  ]
+test =
+  testGroup
+    "Cell"
+    [ testProperty "steps produces outputs" $
+        \(inputs :: [Int]) -> inputs === fst (runIdentity $ steps (id :: Cell Identity Int Int) inputs),
+      testProperty "sumC works as expected" $
+        forAll (vector 100) $ \(inputs :: [Int]) ->
+          sum (init inputs)
+            === last (fst (runIdentity $ steps (sumC :: Cell Identity Int Int) inputs)),
+      Cell.Util.test,
+      Cell.Monad.Trans.test
+    ]

--- a/essence-of-live-coding/test/Cell/Monad/Trans.hs
+++ b/essence-of-live-coding/test/Cell/Monad/Trans.hs
@@ -1,26 +1,28 @@
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
 module Cell.Monad.Trans where
 
 -- transformers
 import Control.Monad.Trans.Reader
-
 -- test-framework
-import Test.Framework
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2
 
 -- QuickCheck
-import Test.QuickCheck hiding (output)
 
 -- essence-of-live-coding
 import LiveCoding
-
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2
+import Test.QuickCheck hiding (output)
 import Util
 
-test = testGroup "Cell.Monad.Trans"
-  [ testProperty "readerC" $ inIdentityT $ proc (n :: Int) -> do
-      nReader <- runReaderC' $ constM ask -< (n, ())
-      returnA -< n === nReader
-  ]
+test =
+  testGroup
+    "Cell.Monad.Trans"
+    [ testProperty "readerC" $
+        inIdentityT $ proc (n :: Int) -> do
+          nReader <- runReaderC' $ constM ask -< (n, ())
+          returnA -< n === nReader
+    ]

--- a/essence-of-live-coding/test/Cell/Util.hs
+++ b/essence-of-live-coding/test/Cell/Util.hs
@@ -1,171 +1,190 @@
 {-# LANGUAGE Arrows #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Cell.Util where
 
 -- base
 import qualified Control.Category as C
-import Data.Functor.Identity
-import Data.Maybe
 import Control.Monad
-import Data.List
-
 -- transformers
 import Control.Monad.Trans.Reader
-
+import Data.Functor.Identity
+import Data.List
+import Data.Maybe
 -- test-framework
-import Test.Framework
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2
 
 -- QuickCheck
-import Test.QuickCheck hiding (output)
 
 -- essence-of-live-coding
 import LiveCoding
-
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2
+import Test.QuickCheck hiding (output)
 import Util
 
-test = testGroup "Utility unit tests"
---   [ testProperty "Buffer works as expected" CellSimulation
---       { cell = buffer
---       , input = []
---     --   , input =
---     --       [ []
---     --       , [Pop]
---     --       , [Push (23 :: Int)]
---     --       , []
---     --       , [Pop, Pop]
---     --       , [Push 42, Pop]
---     --       , [Push 1, Push 2]
---     --       , []
---     --       , []
---     --       , [Pop, Push 3]
---     --       , []
---     --       , [Pop]
---     --       , [Pop]
---     --       , []
---     --       ]
---       , output = []
---     --   , output =
---     --       [ Nothing
---     --       , Nothing
---     --       , Just 23
---     --       , Just 23
---     --       , Nothing
---     --       , Nothing
---     --       , Just 1
---     --       , Just 1
---     --       , Just 1
---     --       , Just 2
---     --       , Just 2
---     --       , Just 3
---     --       , Nothing
---     --       , Nothing
---     --       ]
---       }
-  [ testProperty "buffered works as expected" CellSimulation
-    { cell = buffered C.id
-    , input =
-        [ Just (23 :: Int)
-        ]
-    , output =
-        [ Nothing
-        ]
-    }
-  , testProperty "buffered can be used in an asynchronous setting" $ do
-      jointInputs <- arbitrary -- Simulates when input arrives and when inner cell is activated
-      -- Make sure cell is ticked at the last time, and no new input arrives
-      let innerCell = proc (aMaybe :: Maybe Int) -> do
-            isScheduled <- constM ask -< ()
-            returnA -< guard isScheduled >> aMaybe
-          outerCell = buffered innerCell
-          (outputs, _) = runIdentity $ steps (runReaderC' outerCell) jointInputs
-          labelString = unwords [show jointInputs, show outputs, show $ length jointInputs, show $ length outputs]
-          inputs = snd $ unzip jointInputs
-          bufferNotEmpty = isJust $ listToMaybe $ reverse outputs
-      -- Make sure each message arrived exactly once, in order
-      return
-        $ counterexample labelString
-        $ catMaybes inputs === catMaybes outputs
-        .||. bufferNotEmpty
-  , testProperty "delay a >>> changes >>> hold a == delay a"
-    $ \(inputs :: [Int]) (startValue :: Int) -> fst (runIdentity $ steps (delay startValue) inputs) ===
-        fst (runIdentity $ steps (delay startValue >>> changes >>> hold startValue) inputs)
-  , testProperty "changes applied to a cell that outputs a constant, always outputs Nothing"
-    $ \(value :: Int) (inputs :: [Int]) -> [] ===
-        catMaybes (fst (runIdentity $ steps (arr (const value) >>> changes) inputs))
-  , testProperty "changes works as expected" CellSimulation
-    { cell = changes
-    , input =
-        [ 1 :: Int
-        , 1 :: Int
-        , 2 :: Int
-        , 2 :: Int
-        ]
-    , output =
-        [ Nothing
-        , Nothing
-        , Just (2 :: Int)
-        , Nothing
-        ]
-    }
-  , testProperty "changes migrates correctly to itself" CellMigrationSimulation
-    { cell1 = changes
-    , cell2 = changes
-    , input1 = [1, 2] :: [Int]
-    , input2 = [3, 4] :: [Int]
-    , output1 = [Nothing, Just 2]
-    , output2 = [Just 3, Just 4]
-    }
-  , testProperty "delay migrates correctly to itself" CellMigrationSimulation
-    { cell1 = LiveCoding.delay 0
-    , cell2 = LiveCoding.delay 0
-    , input1 = [1 :: Int, 2, 3, 4]
-    , input2 = [5 :: Int, 6, 7, 8]
-    , output1 = [0, 1, 2, 3]
-    , output2 = [4, 5, 6, 7]
-    }
-  , testProperty "delay migrates correctly with original type wrapped in data type with single constructor" CellMigrationSimulation
-    { cell1 = LiveCoding.delay 0 :: Cell Identity Int Int
-    , cell2 = arr Stuff >>> LiveCoding.delay (Stuff 99) >>> arr (\(Stuff a) -> a) :: Cell Identity Int Int
-    , input1 = [1, 2, 3, 4] :: [Int]
-    , input2 = [10, 10, 10, 10] :: [Int]
-    , output1 = [0, 1, 2, 3] :: [Int]
-    , output2 = [4, 10, 10, 10] :: [Int]
-    }
-  , testProperty "resampleListPar works as expected"
-    $ forAll (vector 100) $ \(inputs :: [(Int, Int)]) -> let
-        inputs' = fmap pairToList inputs
-        pairToList :: (a, a) -> [a]
-        pairToList (x,y) = [x,y]
-      in 
+test =
+  testGroup
+    "Utility unit tests"
+    --   [ testProperty "Buffer works as expected" CellSimulation
+    --       { cell = buffer
+    --       , input = []
+    --     --   , input =
+    --     --       [ []
+    --     --       , [Pop]
+    --     --       , [Push (23 :: Int)]
+    --     --       , []
+    --     --       , [Pop, Pop]
+    --     --       , [Push 42, Pop]
+    --     --       , [Push 1, Push 2]
+    --     --       , []
+    --     --       , []
+    --     --       , [Pop, Push 3]
+    --     --       , []
+    --     --       , [Pop]
+    --     --       , [Pop]
+    --     --       , []
+    --     --       ]
+    --       , output = []
+    --     --   , output =
+    --     --       [ Nothing
+    --     --       , Nothing
+    --     --       , Just 23
+    --     --       , Just 23
+    --     --       , Nothing
+    --     --       , Nothing
+    --     --       , Just 1
+    --     --       , Just 1
+    --     --       , Just 1
+    --     --       , Just 2
+    --     --       , Just 2
+    --     --       , Just 3
+    --     --       , Nothing
+    --     --       , Nothing
+    --     --       ]
+    --       }
+    [ testProperty
+        "buffered works as expected"
         CellSimulation
-        { cell = resampleListPar (sumC :: Cell Identity Int Int)
-        , input = inputs'
-        , output = fmap sum . transpose <$> [[0::Int,0]] : tail (inits (init inputs'))
-        }
-  , testProperty "resampleListPar grow" CellSimulation
-    { cell = resampleListPar (sumC :: Cell Identity Int Int)
-    , input = [[1,1,1],[1,1,1],[1,1,1,1],[1,1,1,1],[1,1,1,1,1]]
-    , output = [[0,0,0],[1,1,1],[2,2,2,0],[3,3,3,1],[4,4,4,2,0]]
-    }
-  , testProperty "resampleListPar shrink" CellSimulation
-    { cell = resampleListPar (sumC :: Cell Identity Int Int)
-    , input = [[1,1,1],[1,1,1],[1,1],[1,1],[1],[]]
-    , output = [[0,0,0],[1,1,1],[2,2],[3,3],[4],[]]
-    }
-  , testProperty "resampleListPar grow then shrink" CellSimulation
-    { cell = resampleListPar (sumC :: Cell Identity Int Int)
-    , input = [[1,1,1],[1,1,1,1],[1,1,1]]
-    , output = [[0,0,0],[1,1,1,0],[2,2,2]]
-    }
-  , testProperty "resampleListPar shrink then grow" CellSimulation
-    { cell = resampleListPar (sumC :: Cell Identity Int Int)
-    , input = [[1,1,1],[1,1],[1,1,1]]
-    , output = [[0,0,0],[1,1],[2,2,0]]
-    }
-  ]
+          { cell = buffered C.id,
+            input =
+              [ Just (23 :: Int)
+              ],
+            output =
+              [ Nothing
+              ]
+          },
+      testProperty "buffered can be used in an asynchronous setting" $ do
+        jointInputs <- arbitrary -- Simulates when input arrives and when inner cell is activated
+        -- Make sure cell is ticked at the last time, and no new input arrives
+        let innerCell = proc (aMaybe :: Maybe Int) -> do
+              isScheduled <- constM ask -< ()
+              returnA -< guard isScheduled >> aMaybe
+            outerCell = buffered innerCell
+            (outputs, _) = runIdentity $ steps (runReaderC' outerCell) jointInputs
+            labelString = unwords [show jointInputs, show outputs, show $ length jointInputs, show $ length outputs]
+            inputs = snd $ unzip jointInputs
+            bufferNotEmpty = isJust $ listToMaybe $ reverse outputs
+        -- Make sure each message arrived exactly once, in order
+        return $
+          counterexample labelString $
+            catMaybes inputs === catMaybes outputs
+              .||. bufferNotEmpty,
+      testProperty "delay a >>> changes >>> hold a == delay a" $
+        \(inputs :: [Int]) (startValue :: Int) ->
+          fst (runIdentity $ steps (delay startValue) inputs)
+            === fst (runIdentity $ steps (delay startValue >>> changes >>> hold startValue) inputs),
+      testProperty "changes applied to a cell that outputs a constant, always outputs Nothing" $
+        \(value :: Int) (inputs :: [Int]) ->
+          []
+            === catMaybes (fst (runIdentity $ steps (arr (const value) >>> changes) inputs)),
+      testProperty
+        "changes works as expected"
+        CellSimulation
+          { cell = changes,
+            input =
+              [ 1 :: Int,
+                1 :: Int,
+                2 :: Int,
+                2 :: Int
+              ],
+            output =
+              [ Nothing,
+                Nothing,
+                Just (2 :: Int),
+                Nothing
+              ]
+          },
+      testProperty
+        "changes migrates correctly to itself"
+        CellMigrationSimulation
+          { cell1 = changes,
+            cell2 = changes,
+            input1 = [1, 2] :: [Int],
+            input2 = [3, 4] :: [Int],
+            output1 = [Nothing, Just 2],
+            output2 = [Just 3, Just 4]
+          },
+      testProperty
+        "delay migrates correctly to itself"
+        CellMigrationSimulation
+          { cell1 = LiveCoding.delay 0,
+            cell2 = LiveCoding.delay 0,
+            input1 = [1 :: Int, 2, 3, 4],
+            input2 = [5 :: Int, 6, 7, 8],
+            output1 = [0, 1, 2, 3],
+            output2 = [4, 5, 6, 7]
+          },
+      testProperty
+        "delay migrates correctly with original type wrapped in data type with single constructor"
+        CellMigrationSimulation
+          { cell1 = LiveCoding.delay 0 :: Cell Identity Int Int,
+            cell2 = arr Stuff >>> LiveCoding.delay (Stuff 99) >>> arr (\(Stuff a) -> a) :: Cell Identity Int Int,
+            input1 = [1, 2, 3, 4] :: [Int],
+            input2 = [10, 10, 10, 10] :: [Int],
+            output1 = [0, 1, 2, 3] :: [Int],
+            output2 = [4, 10, 10, 10] :: [Int]
+          },
+      testProperty "resampleListPar works as expected" $
+        forAll (vector 100) $ \(inputs :: [(Int, Int)]) ->
+          let inputs' = fmap pairToList inputs
+              pairToList :: (a, a) -> [a]
+              pairToList (x, y) = [x, y]
+           in CellSimulation
+                { cell = resampleListPar (sumC :: Cell Identity Int Int),
+                  input = inputs',
+                  output = fmap sum . transpose <$> [[0 :: Int, 0]] : tail (inits (init inputs'))
+                },
+      testProperty
+        "resampleListPar grow"
+        CellSimulation
+          { cell = resampleListPar (sumC :: Cell Identity Int Int),
+            input = [[1, 1, 1], [1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1]],
+            output = [[0, 0, 0], [1, 1, 1], [2, 2, 2, 0], [3, 3, 3, 1], [4, 4, 4, 2, 0]]
+          },
+      testProperty
+        "resampleListPar shrink"
+        CellSimulation
+          { cell = resampleListPar (sumC :: Cell Identity Int Int),
+            input = [[1, 1, 1], [1, 1, 1], [1, 1], [1, 1], [1], []],
+            output = [[0, 0, 0], [1, 1, 1], [2, 2], [3, 3], [4], []]
+          },
+      testProperty
+        "resampleListPar grow then shrink"
+        CellSimulation
+          { cell = resampleListPar (sumC :: Cell Identity Int Int),
+            input = [[1, 1, 1], [1, 1, 1, 1], [1, 1, 1]],
+            output = [[0, 0, 0], [1, 1, 1, 0], [2, 2, 2]]
+          },
+      testProperty
+        "resampleListPar shrink then grow"
+        CellSimulation
+          { cell = resampleListPar (sumC :: Cell Identity Int Int),
+            input = [[1, 1, 1], [1, 1], [1, 1, 1]],
+            output = [[0, 0, 0], [1, 1], [2, 2, 0]]
+          }
+    ]
 
 data Stuff a = Stuff a deriving (Eq, Data)

--- a/essence-of-live-coding/test/Feedback.hs
+++ b/essence-of-live-coding/test/Feedback.hs
@@ -1,47 +1,55 @@
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE RecordWildCards #-}
+
 module Feedback where
 
 -- essence-of-live-coding
-import Util
 
 -- test-framework
-import Test.Framework
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2
 
 -- QuickCheck
-import Test.QuickCheck
 
 -- essence-of-live-coding
 import LiveCoding
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2
+import Test.QuickCheck
+import Util
 
 constCell :: Monad m => Int -> Cell m () Int
-constCell cellState = Cell
-  { cellStep = \state _ -> return (state, state)
-  , ..
-  }
+constCell cellState =
+  Cell
+    { cellStep = \state _ -> return (state, state),
+      ..
+    }
 
-test = testGroup "Feedback"
-  [ testProperty "Migrates into feedback" CellMigrationSimulation
-      { cell1 = constCell 23
-      , cell2 = feedback [] $ proc ((), ns) -> do
-          n <- constCell 42 -< ()
-          returnA -< (sum ns, n : ns)
-      , input1 = replicate 3 ()
-      , input2 = replicate 3 ()
-      , output1 = [23, 23, 23]
-      , output2 = [0, 23, 46]
-      }
-  , testProperty "Migrates out of feedback" CellMigrationSimulation
-      { cell1 = feedback [] $ proc ((), ns) -> do
-          n <- constCell 23 -< ()
-          returnA -< (sum ns, n : ns)
-      , cell2 = constCell 42
-      , input1 = replicate 3 ()
-      , input2 = replicate 3 ()
-      , output1 = [0, 23, 46]
-      , output2 = [23, 23, 23]
-      }
-  ]
+test =
+  testGroup
+    "Feedback"
+    [ testProperty
+        "Migrates into feedback"
+        CellMigrationSimulation
+          { cell1 = constCell 23,
+            cell2 = feedback [] $ proc ((), ns) -> do
+              n <- constCell 42 -< ()
+              returnA -< (sum ns, n : ns),
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = [23, 23, 23],
+            output2 = [0, 23, 46]
+          },
+      testProperty
+        "Migrates out of feedback"
+        CellMigrationSimulation
+          { cell1 = feedback [] $ proc ((), ns) -> do
+              n <- constCell 23 -< ()
+              returnA -< (sum ns, n : ns),
+            cell2 = constCell 42,
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = [0, 23, 46],
+            output2 = [23, 23, 23]
+          }
+    ]

--- a/essence-of-live-coding/test/Handle.hs
+++ b/essence-of-live-coding/test/Handle.hs
@@ -5,53 +5,56 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+
 module Handle where
 
 -- base
 import Control.Arrow
-import Data.Functor
-import Data.Functor.Identity
-
 -- transformers
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict
-
+import Data.Functor
+import Data.Functor.Identity
 -- test-framework
-import Test.Framework
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2
 
 -- essence-of-live-coding
+
+import GHC.Base (Nat, Symbol)
+import GHC.Natural (naturalToInteger)
+import GHC.TypeNats (KnownNat, natVal)
 import qualified Handle.LiveProgram
 import LiveCoding
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2
 import Util
-import GHC.Base (Symbol, Nat)
-import GHC.TypeNats (natVal, KnownNat)
-import GHC.Natural (naturalToInteger)
 
 -- One day replace State Int with Writer [String]
 testHandle :: Handle (State Int) String
-testHandle = Handle
-  { create = do
-      n <- get
-      return $ "Handle #" ++ show n
-  , destroy = const $ put 10000
-  }
+testHandle =
+  Handle
+    { create = do
+        n <- get
+        return $ "Handle #" ++ show n,
+      destroy = const $ put 10000
+    }
 
 testUnitHandle :: Handle (State Int) ()
-testUnitHandle = Handle
-  { create = return ()
-  , destroy = const $ put 20000
-  }
+testUnitHandle =
+  Handle
+    { create = return (),
+      destroy = const $ put 20000
+    }
 
-cellWithAction
-  :: forall a b . State Int b
-  -> Cell Identity a (String, Int)
+cellWithAction ::
+  forall a b.
+  State Int b ->
+  Cell Identity a (String, Int)
 cellWithAction action = flip runStateC 0 $ runHandlingStateC $ handling testHandle >>> arrM (<$ lift action)
 
 testParametrisedHandle :: ParametrisedHandle Bool (State Int) String
-testParametrisedHandle = ParametrisedHandle { .. }
+testParametrisedHandle = ParametrisedHandle {..}
   where
     createParametrised flag = do
       n <- get
@@ -60,13 +63,14 @@ testParametrisedHandle = ParametrisedHandle { .. }
     destroyParametrised = const $ const $ put 12345
     changeParametrised = defaultChange createParametrised destroyParametrised
 
-cellWithActionParametrized
-  :: forall a b . State Int b
-  -> Cell Identity Bool (String, Int)
-cellWithActionParametrized action
-  = flip runStateC 0
-  $ runHandlingStateC
-  $ handlingParametrised testParametrisedHandle >>> arrM (<$ lift action)
+cellWithActionParametrized ::
+  forall a b.
+  State Int b ->
+  Cell Identity Bool (String, Int)
+cellWithActionParametrized action =
+  flip runStateC 0 $
+    runHandlingStateC $
+      handlingParametrised testParametrisedHandle >>> arrM (<$ lift action)
 
 throwAfter2Steps :: Monad m => Cell (ExceptT () m) a Int
 throwAfter2Steps = arr (const 1) >>> sumC >>> throwIf_ (> 1)
@@ -75,117 +79,147 @@ data Tag (tag :: Nat) = Tag
   deriving (Eq, Show)
 
 testTypelevelHandle :: KnownNat tag => Handle (State Int) (Tag tag)
-testTypelevelHandle = Handle
-  { create = return Tag
-  , destroy = put . fromInteger . naturalToInteger . natVal
-  }
+testTypelevelHandle =
+  Handle
+    { create = return Tag,
+      destroy = put . fromInteger . naturalToInteger . natVal
+    }
 
-cellWithActionTypelevel
-  :: KnownNat tag
-  => State Int b
-  -> Cell Identity a (Tag tag, Int)
-cellWithActionTypelevel action
-  = flip runStateC 0
-  $ runHandlingStateC
-  $ handling testTypelevelHandle >>> arrM (<$ lift action)
+cellWithActionTypelevel ::
+  KnownNat tag =>
+  State Int b ->
+  Cell Identity a (Tag tag, Int)
+cellWithActionTypelevel action =
+  flip runStateC 0 $
+    runHandlingStateC $
+      handling testTypelevelHandle >>> arrM (<$ lift action)
 
-test = testGroup "Handle"
-  [ testProperty "Preserve Handles" CellMigrationSimulation
-    { cell1 = cellWithAction $ modify (+ 1)
-    , cell2 = cellWithAction $ return ()
-    , input1 = replicate 3 ()
-    , input2 = replicate 3 ()
-    , output1 = ("Handle #0", ) <$> [1, 2, 3]
-    , output2 = ("Handle #0", ) <$> [3, 3, 3]
-    }
-  , testProperty "Initialise Handles upon migration" CellMigrationSimulation
-    { cell1 = flip runStateC 0 $ constM $ modify (+ 1) >> return ""
-    , cell2 = cellWithAction $ return ()
-    , input1 = replicate 3 ()
-    , input2 = replicate 3 ()
-    , output1 = ("", ) <$> [1, 2, 3]
-    , output2 = ("Handle #3", ) <$> [3, 3, 3]
-    }
-  , testProperty "Preserve Handles in more complex migration" CellMigrationSimulation
-    { cell1 = flip runStateC 22
-        $ constM (modify (+ 1)) >>> runHandlingStateC (handling testHandle)
-    , cell2 = cellWithAction $ return ()
-    , input1 = replicate 3 ()
-    , input2 = replicate 3 ()
-    , output1 = ("Handle #23", ) <$> [23, 24, 25]
-    , output2 = ("Handle #23", ) <$> replicate 3 25
-    }
-  , testProperty "Reinitialise Handles in too complex migration" CellMigrationSimulation
-    { cell1 = flip runStateC 22
-        $   constM (modify (+ 1))
-        >>> constM get >>> sumC >>> sumC
-        >>> runHandlingStateC (handling testHandle)
-    , cell2 = cellWithAction $ return ()
-    , input1 = replicate 3 ()
-    , input2 = replicate 3 ()
-    , output1 = ("Handle #23", ) <$> [23, 24, 25]
-    , output2 = ("Handle #25", ) <$> replicate 3 25
-    }
-  , testProperty "Doesn't crash when handle is introspected by migration" CellMigrationSimulation
-    { cell1 = cellWithAction $ return ()
-    , cell2 = flip runStateC 0 $ runHandlingStateC
-        $ handling testUnitHandle >>> arr (const "")
-    , input1 = replicate 3 ()
-    , input2 = replicate 3 ()
-    , output1 = ("Handle #0", ) <$> replicate 3 0
-    , output2 = ("", ) <$> replicate 3 10000
-    }
-  , testProperty "Trigger destructors" CellMigrationSimulation
-    { cell1 = cellWithAction $ return ()
-    , cell2 = flip runStateC 23
-        $ runHandlingStateC $ arr $ const "Done"
-    , input1 = replicate 3 ()
-    , input2 = replicate 3 ()
-    , output1 = ("Handle #0", ) <$> replicate 3 0
-    , output2 = ("Done", ) <$> replicate 3 10000
-    }
-  , testProperty "Changing parameters triggers destructors" CellSimulation
-    { cell = cellWithActionParametrized $ modify (+ 1)
-    , input = [True, True, False, False]
-    , output =
-        [ ("Ye Olde Handle No 0", 1)
-        , ("Ye Olde Handle No 0", 2)
-        , ("Crazy new hdl #12345", 12346)
-        , ("Crazy new hdl #12345", 12347)
-        ]
-    }
-  , testProperty "Transient control flow does not trigger destructors or constructors" CellSimulation
-    { cell = cellWithAction (modify (+ 1)) ||| arr (const ("Nope", 23))
-    , input = [Right (), Left (), Left (), Right (), Left ()]
-    , output =
-        [ ("Nope", 23)
-        , ("Handle #0", 1)
-        , ("Handle #0", 2)
-        , ("Nope", 23)
-        , ("Handle #0", 3)
-        ]
-    }
-  , testProperty "Permanent control flow does not trigger destructors or constructors" CellSimulation
-    { cell = safely $ do
-        void $ try $ throwAfter2Steps >>> arr (const ("Nope", 23))
-        void $ try $ throwAfter2Steps >>> liftCell (cellWithAction (modify (+ 1)))
-        safe $ arr $ const ("Nope", 23)
-    , input = replicate 5 ()
-    , output =
-        [ ("Nope", 23)
-        , ("Nope", 23)
-        , ("Handle #0", 1)
-        , ("Handle #0", 2)
-        , ("Nope", 23)
-        ]
-    }
-  , testProperty "Change of type level tags trigger destructors" CellMigrationSimulation
-    { cell1 = (cellWithActionTypelevel @23000 $ modify (+ 1)) >>> arr snd
-    , cell2 = (cellWithActionTypelevel @42000 $ modify (+ 2)) >>> arr snd
-    , input1 = replicate 3 ()
-    , input2 = replicate 3 ()
-    , output1 = [1, 2, 3]
-    , output2 = [23000, 23002, 23004]
-    }
-  , Handle.LiveProgram.test
-  ]
+test =
+  testGroup
+    "Handle"
+    [ testProperty
+        "Preserve Handles"
+        CellMigrationSimulation
+          { cell1 = cellWithAction $ modify (+ 1),
+            cell2 = cellWithAction $ return (),
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = ("Handle #0",) <$> [1, 2, 3],
+            output2 = ("Handle #0",) <$> [3, 3, 3]
+          },
+      testProperty
+        "Initialise Handles upon migration"
+        CellMigrationSimulation
+          { cell1 = flip runStateC 0 $ constM $ modify (+ 1) >> return "",
+            cell2 = cellWithAction $ return (),
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = ("",) <$> [1, 2, 3],
+            output2 = ("Handle #3",) <$> [3, 3, 3]
+          },
+      testProperty
+        "Preserve Handles in more complex migration"
+        CellMigrationSimulation
+          { cell1 =
+              flip runStateC 22 $
+                constM (modify (+ 1)) >>> runHandlingStateC (handling testHandle),
+            cell2 = cellWithAction $ return (),
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = ("Handle #23",) <$> [23, 24, 25],
+            output2 = ("Handle #23",) <$> replicate 3 25
+          },
+      testProperty
+        "Reinitialise Handles in too complex migration"
+        CellMigrationSimulation
+          { cell1 =
+              flip runStateC 22 $
+                constM (modify (+ 1))
+                  >>> constM get
+                  >>> sumC
+                  >>> sumC
+                  >>> runHandlingStateC (handling testHandle),
+            cell2 = cellWithAction $ return (),
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = ("Handle #23",) <$> [23, 24, 25],
+            output2 = ("Handle #25",) <$> replicate 3 25
+          },
+      testProperty
+        "Doesn't crash when handle is introspected by migration"
+        CellMigrationSimulation
+          { cell1 = cellWithAction $ return (),
+            cell2 =
+              flip runStateC 0 $
+                runHandlingStateC $
+                  handling testUnitHandle >>> arr (const ""),
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = ("Handle #0",) <$> replicate 3 0,
+            output2 = ("",) <$> replicate 3 10000
+          },
+      testProperty
+        "Trigger destructors"
+        CellMigrationSimulation
+          { cell1 = cellWithAction $ return (),
+            cell2 =
+              flip runStateC 23 $
+                runHandlingStateC $ arr $ const "Done",
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = ("Handle #0",) <$> replicate 3 0,
+            output2 = ("Done",) <$> replicate 3 10000
+          },
+      testProperty
+        "Changing parameters triggers destructors"
+        CellSimulation
+          { cell = cellWithActionParametrized $ modify (+ 1),
+            input = [True, True, False, False],
+            output =
+              [ ("Ye Olde Handle No 0", 1),
+                ("Ye Olde Handle No 0", 2),
+                ("Crazy new hdl #12345", 12346),
+                ("Crazy new hdl #12345", 12347)
+              ]
+          },
+      testProperty
+        "Transient control flow does not trigger destructors or constructors"
+        CellSimulation
+          { cell = cellWithAction (modify (+ 1)) ||| arr (const ("Nope", 23)),
+            input = [Right (), Left (), Left (), Right (), Left ()],
+            output =
+              [ ("Nope", 23),
+                ("Handle #0", 1),
+                ("Handle #0", 2),
+                ("Nope", 23),
+                ("Handle #0", 3)
+              ]
+          },
+      testProperty
+        "Permanent control flow does not trigger destructors or constructors"
+        CellSimulation
+          { cell = safely $ do
+              void $ try $ throwAfter2Steps >>> arr (const ("Nope", 23))
+              void $ try $ throwAfter2Steps >>> liftCell (cellWithAction (modify (+ 1)))
+              safe $ arr $ const ("Nope", 23),
+            input = replicate 5 (),
+            output =
+              [ ("Nope", 23),
+                ("Nope", 23),
+                ("Handle #0", 1),
+                ("Handle #0", 2),
+                ("Nope", 23)
+              ]
+          },
+      testProperty
+        "Change of type level tags trigger destructors"
+        CellMigrationSimulation
+          { cell1 = (cellWithActionTypelevel @23000 $ modify (+ 1)) >>> arr snd,
+            cell2 = (cellWithActionTypelevel @42000 $ modify (+ 2)) >>> arr snd,
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 = [1, 2, 3],
+            output2 = [23000, 23002, 23004]
+          },
+      Handle.LiveProgram.test
+    ]

--- a/essence-of-live-coding/test/Handle/LiveProgram.hs
+++ b/essence-of-live-coding/test/Handle/LiveProgram.hs
@@ -1,56 +1,64 @@
 {-# LANGUAGE RecordWildCards #-}
+
 module Handle.LiveProgram where
 
 -- base
 import Control.Arrow
-
 -- containers
-import qualified Data.IntMap as IntMap
 
 -- transformers
-import Control.Monad.Trans.Class (MonadTrans(lift))
+import Control.Monad.Trans.Class (MonadTrans (lift))
 import Control.Monad.Trans.RWS.Strict (RWS, tell)
 import qualified Control.Monad.Trans.RWS.Strict as RWS
 import Control.Monad.Trans.State.Strict
-
+import qualified Data.IntMap as IntMap
 -- test-framework
-import Test.Framework
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2
 
 -- essence-of-live-coding
 import LiveCoding
 import LiveCoding.Handle
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2
 import Util.LiveProgramMigration
 
 testHandle :: Handle (RWS () [String] Int) String
-testHandle = Handle
-  { create = do
-      n <- RWS.get
-      let msg = "Handle #" ++ show n
-      tell ["Creating " ++ msg]
-      return msg
-  , destroy = const $ tell ["Destroyed handle"]
-  }
-
-test = testGroup "Handle.LiveProgram"
-  [ testProperty "Trigger destructors in live program" LiveProgramMigration
-    { liveProgram1 = runHandlingState $ liveCell
-        $ handling testHandle >>> arrM (lift . tell . return) >>> constM inspectHandlingState
-    , liveProgram2 = runHandlingState mempty
-    , input1 = replicate 3 ()
-    , input2 = replicate 3 ()
-    , output1 = ["Creating Handle #0", "Handle #0", "Handles: 1", "Destructors: (1,True)"]
-        : replicate 2 ["Handle #0", "Handles: 1", "Destructors: (1,True)"]
-    , output2 = [["Destroyed handle"], [], []]
-    , initialState = 0
+testHandle =
+  Handle
+    { create = do
+        n <- RWS.get
+        let msg = "Handle #" ++ show n
+        tell ["Creating " ++ msg]
+        return msg,
+      destroy = const $ tell ["Destroyed handle"]
     }
-  ]
-    where
-      inspectHandlingState = do
-        HandlingState { .. } <- get
-        lift $ tell
-          [ "Handles: " ++ show nHandles
-          , "Destructors: " ++ unwords (show . second isRegistered <$> IntMap.toList destructors)
+
+test =
+  testGroup
+    "Handle.LiveProgram"
+    [ testProperty
+        "Trigger destructors in live program"
+        LiveProgramMigration
+          { liveProgram1 =
+              runHandlingState $
+                liveCell $
+                  handling testHandle >>> arrM (lift . tell . return) >>> constM inspectHandlingState,
+            liveProgram2 = runHandlingState mempty,
+            input1 = replicate 3 (),
+            input2 = replicate 3 (),
+            output1 =
+              ["Creating Handle #0", "Handle #0", "Handles: 1", "Destructors: (1,True)"] :
+              replicate 2 ["Handle #0", "Handles: 1", "Destructors: (1,True)"],
+            output2 = [["Destroyed handle"], [], []],
+            initialState = 0
+          }
+    ]
+  where
+    inspectHandlingState = do
+      HandlingState {..} <- get
+      lift $
+        tell
+          [ "Handles: " ++ show nHandles,
+            "Destructors: " ++ unwords (show . second isRegistered <$> IntMap.toList destructors)
           ]

--- a/essence-of-live-coding/test/Main.hs
+++ b/essence-of-live-coding/test/Main.hs
@@ -1,35 +1,32 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- base
-import Control.Arrow
-import Data.Functor.Identity
 
 -- test-framework
-import Test.Framework
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2
 
 -- QuickCheck
-import Test.QuickCheck
 
 -- essence-of-live-coding
 import qualified Cell
+import Control.Arrow
+import Data.Functor.Identity
 import qualified Feedback
 import qualified Handle
+import LiveCoding
+import qualified Migrate.NoMigration
 import qualified Monad
 import qualified Monad.Trans
 import qualified RuntimeIO.Launch
-import qualified Migrate.NoMigration
-
-import LiveCoding
-
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2
+import Test.QuickCheck
 import qualified TestData.Foo1 as Foo1
 import qualified TestData.Foo2 as Foo2
-
 import Util
 
 intToInteger :: Int -> Integer
@@ -38,94 +35,111 @@ intToInteger = toInteger
 main = defaultMain tests
 
 tests =
-  [ testGroup "Builtin types"
-    [ testProperty "Same"
-      $ \(x :: Integer) (y :: Integer) -> x === migrate y x
-    , testProperty "Different"
-      $ \(x :: Integer) (y :: Bool) -> y === migrate y x
-    ]
-  , testGroup "Product types"
-    [ testProperty "Adds default field"
-      $ Foo1.foo' === migrate Foo1.foo Foo2.foo
-    , testProperty "Keeps only sensible field"
-      $ Foo2.foo' === migrate Foo2.foo Foo1.foo
-    ]
-  , testGroup "Records"
-    [ testProperty "Takes record field names into account"
-      $ \barA barB barC barC2 barD
-      -> Foo2.Bar { barC = barC2, .. } === migrate Foo2.Bar { barC = barC2, .. } Foo1.Bar { .. }
-    , testProperty "Migrates nested records"
-      $ Foo2.baz' === migrate Foo2.baz Foo1.baz
-    ]
-  , testGroup "Constructors"
-    [ testProperty "Finds correct constructor"
-      $ \x y z -> migrate (Foo2.Fooo z) (Foo1.Foo x y) === Foo2.Foo x
-    , testProperty "Finds correct constructor with records"
-      $ \barA barB barC baarA baarB -> migrate Foo2.Bar { .. } Foo1.Baar { .. } === Foo2.Baar { .. }
-    , testProperty "Finds correct constructor if type doesn't change"
-      $ \(x :: Int) -> migrate Nothing (Just x) === Just x
-    ]
-  , testGroup "User migration"
-    [ testProperty "Can add migration from Int to Integer"
-      $ Foo2.frob' === migrateWith (userMigration intToInteger) Foo2.frob Foo1.frob
-    ]
-  , testGroup "Newtypes"
-    [ testProperty "Wraps into newtype"
-      $ \(x :: Integer) -> Foo2.Frob x === migrate Foo2.frob x
-    ]
-  , testGroup "Debugging"
-    [ testProperty "To debugging state"
-      $ \(x :: Int) (y :: Int) (z :: Int)
-      -> Debugging { dbgState = x, state = y } === migrate Debugging { dbgState = x, state = z } y
-    , testProperty "From debugging state"
-    $ \(x :: Int) (y :: Int) (z :: Int)
-    -> x === migrate y Debugging { dbgState = z, state = x }
-    ]
-  , testGroup "Cells"
-    [ testGroup "Sequential composition"
-      [ testProperty "From 1" CellMigrationSimulation
-          { cell1 = sumC >>> arr toInteger
-          , cell2 = sumC >>> arr toInteger >>> sumC
-          , input1 = [1, 1, 1] :: [Int]
-          , input2 = [1, 1, 1]
-          , output1 = [0, 1, 2]
-          , output2 = [0, 3, 7]
-          }
-      ]
-    , testGroup "Choice"
-      [ testProperty "From left" CellMigrationSimulation
-        { cell1 = arr fromEither >>> sumC >>> arr toInteger
-        , cell2 = (sumC >>> arr toInteger) ||| (arr toInteger >>> sumC)
-        , input1 = [Left  1, Right 1, Left  (1 :: Int)]
-        , input2 = [Right 1, Left  1, Right 1]
-        , output1 = [0, 1, 2]
-        , output2 = [0, 3, 1]
-        }
-      ]
-    , testGroup "Control flow"
-      [ testProperty "Into safe" CellMigrationSimulation
-        { cell1 = countFrom 0
-        , cell2 = safely $ do
-            try $ countFrom 10  >>> throwIf (>  1) ()
-            safe $ countFrom 20
-        , input1 = replicate 3 ()
-        , input2 = replicate 3 ()
-        , output1 = [0, 1, 2]
-        , output2 = [23, 24, 25]
-        }
-      ]
-    , Cell.test
-    , Handle.test
-    , Migrate.NoMigration.test
-    , Monad.test
-    , Feedback.test
-    ]
-  , Monad.Trans.test
-  , RuntimeIO.Launch.test
+  [ testGroup
+      "Builtin types"
+      [ testProperty "Same" $
+          \(x :: Integer) (y :: Integer) -> x === migrate y x,
+        testProperty "Different" $
+          \(x :: Integer) (y :: Bool) -> y === migrate y x
+      ],
+    testGroup
+      "Product types"
+      [ testProperty "Adds default field" $
+          Foo1.foo' === migrate Foo1.foo Foo2.foo,
+        testProperty "Keeps only sensible field" $
+          Foo2.foo' === migrate Foo2.foo Foo1.foo
+      ],
+    testGroup
+      "Records"
+      [ testProperty "Takes record field names into account" $
+          \barA barB barC barC2 barD ->
+            Foo2.Bar {barC = barC2, ..} === migrate Foo2.Bar {barC = barC2, ..} Foo1.Bar {..},
+        testProperty "Migrates nested records" $
+          Foo2.baz' === migrate Foo2.baz Foo1.baz
+      ],
+    testGroup
+      "Constructors"
+      [ testProperty "Finds correct constructor" $
+          \x y z -> migrate (Foo2.Fooo z) (Foo1.Foo x y) === Foo2.Foo x,
+        testProperty "Finds correct constructor with records" $
+          \barA barB barC baarA baarB -> migrate Foo2.Bar {..} Foo1.Baar {..} === Foo2.Baar {..},
+        testProperty "Finds correct constructor if type doesn't change" $
+          \(x :: Int) -> migrate Nothing (Just x) === Just x
+      ],
+    testGroup
+      "User migration"
+      [ testProperty "Can add migration from Int to Integer" $
+          Foo2.frob' === migrateWith (userMigration intToInteger) Foo2.frob Foo1.frob
+      ],
+    testGroup
+      "Newtypes"
+      [ testProperty "Wraps into newtype" $
+          \(x :: Integer) -> Foo2.Frob x === migrate Foo2.frob x
+      ],
+    testGroup
+      "Debugging"
+      [ testProperty "To debugging state" $
+          \(x :: Int) (y :: Int) (z :: Int) ->
+            Debugging {dbgState = x, state = y} === migrate Debugging {dbgState = x, state = z} y,
+        testProperty "From debugging state" $
+          \(x :: Int) (y :: Int) (z :: Int) ->
+            x === migrate y Debugging {dbgState = z, state = x}
+      ],
+    testGroup
+      "Cells"
+      [ testGroup
+          "Sequential composition"
+          [ testProperty
+              "From 1"
+              CellMigrationSimulation
+                { cell1 = sumC >>> arr toInteger,
+                  cell2 = sumC >>> arr toInteger >>> sumC,
+                  input1 = [1, 1, 1] :: [Int],
+                  input2 = [1, 1, 1],
+                  output1 = [0, 1, 2],
+                  output2 = [0, 3, 7]
+                }
+          ],
+        testGroup
+          "Choice"
+          [ testProperty
+              "From left"
+              CellMigrationSimulation
+                { cell1 = arr fromEither >>> sumC >>> arr toInteger,
+                  cell2 = (sumC >>> arr toInteger) ||| (arr toInteger >>> sumC),
+                  input1 = [Left 1, Right 1, Left (1 :: Int)],
+                  input2 = [Right 1, Left 1, Right 1],
+                  output1 = [0, 1, 2],
+                  output2 = [0, 3, 1]
+                }
+          ],
+        testGroup
+          "Control flow"
+          [ testProperty
+              "Into safe"
+              CellMigrationSimulation
+                { cell1 = countFrom 0,
+                  cell2 = safely $ do
+                    try $ countFrom 10 >>> throwIf (> 1) ()
+                    safe $ countFrom 20,
+                  input1 = replicate 3 (),
+                  input2 = replicate 3 (),
+                  output1 = [0, 1, 2],
+                  output2 = [23, 24, 25]
+                }
+          ],
+        Cell.test,
+        Handle.test,
+        Migrate.NoMigration.test,
+        Monad.test,
+        Feedback.test
+      ],
+    Monad.Trans.test,
+    RuntimeIO.Launch.test
   ]
 
 countFrom :: Monad m => Int -> Cell m () Int
 countFrom n = arr (const 1) >>> sumC >>> arr (+ n)
 
-fromEither (Left  a) = a
+fromEither (Left a) = a
 fromEither (Right a) = a

--- a/essence-of-live-coding/test/Migrate/NoMigration.hs
+++ b/essence-of-live-coding/test/Migrate/NoMigration.hs
@@ -1,43 +1,49 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Migrate.NoMigration where
 
 -- base
-import Control.Arrow ( Arrow(arr), (>>>) )
-import Data.Maybe (fromJust)
+import Control.Arrow (Arrow (arr), (>>>))
 import Data.Data (Data)
-
+import Data.Maybe (fromJust)
 -- test-framework
-import Test.Framework ( testGroup )
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2 ( testProperty )
 
 -- essence-of-live-coding
-import Util
+
 import qualified LiveCoding.Migrate.NoMigration as NoMigration
+import Test.Framework (testGroup)
+import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Util
 
 data Stuff a = Stuff a deriving (Eq, Data)
 
-test = testGroup "NoMigration unit tests"
-  [ testProperty "LiveCoding.Migrate.NoMigration.delay migrates correctly to itself" CellMigrationSimulation
-    { cell1 = NoMigration.delay 0
-    , cell2 = NoMigration.delay 0
-    , input1 = [1 :: Int, 2, 3, 4]
-    , input2 = [5 :: Int, 6, 7, 8]
-    , output1 = [0, 1, 2, 3]
-    , output2 = [4, 5, 6, 7]
-    }
-  , testProperty "LiveCoding.Migrate.NoMigration.delay different type will not migrate" CellMigrationSimulation
-    { cell1 = NoMigration.delay 0
-    , cell2 = arr Stuff >>> NoMigration.delay (Stuff 99) >>> arr (\(Stuff a) -> a)
-    , input1 = [1 :: Int, 2, 3, 4]
-    , input2 = [10 :: Int, 10, 10, 10]
-    , output1 = [0, 1, 2, 3]
-    , output2 = [99, 10, 10, 10]
-     }
-  ]
+test =
+  testGroup
+    "NoMigration unit tests"
+    [ testProperty
+        "LiveCoding.Migrate.NoMigration.delay migrates correctly to itself"
+        CellMigrationSimulation
+          { cell1 = NoMigration.delay 0,
+            cell2 = NoMigration.delay 0,
+            input1 = [1 :: Int, 2, 3, 4],
+            input2 = [5 :: Int, 6, 7, 8],
+            output1 = [0, 1, 2, 3],
+            output2 = [4, 5, 6, 7]
+          },
+      testProperty
+        "LiveCoding.Migrate.NoMigration.delay different type will not migrate"
+        CellMigrationSimulation
+          { cell1 = NoMigration.delay 0,
+            cell2 = arr Stuff >>> NoMigration.delay (Stuff 99) >>> arr (\(Stuff a) -> a),
+            input1 = [1 :: Int, 2, 3, 4],
+            input2 = [10 :: Int, 10, 10, 10],
+            output1 = [0, 1, 2, 3],
+            output2 = [99, 10, 10, 10]
+          }
+    ]

--- a/essence-of-live-coding/test/Monad.hs
+++ b/essence-of-live-coding/test/Monad.hs
@@ -2,22 +2,23 @@ module Monad where
 
 -- transformers
 import Control.Monad.Trans.State.Strict
-
 -- essence-of-live-coding
-import LiveCoding
-import LiveCoding.Cell.Monad.Trans
-import Util
 
 import Data.Functor.Identity (Identity)
-
+import LiveCoding
+import LiveCoding.Cell.Monad.Trans
 -- test-framework-quickcheck2
 import Test.Framework.Providers.QuickCheck2
+import Util
 
-test = testProperty "State effect" CellMigrationSimulation
-  { cell1 = flip runStateC (0 :: Int) $ constM (modify (+ 1))
-  , cell2 = flip runStateC 23 $ constM (modify (+ 2))
-  , input1 = [(), (), ()]
-  , input2 = [(), (), ()]
-  , output1 = [((), 1), ((), 2), ((), 3)]
-  , output2 = [((), 5), ((), 7), ((), 9)]
-  }
+test =
+  testProperty
+    "State effect"
+    CellMigrationSimulation
+      { cell1 = flip runStateC (0 :: Int) $ constM (modify (+ 1)),
+        cell2 = flip runStateC 23 $ constM (modify (+ 2)),
+        input1 = [(), (), ()],
+        input2 = [(), (), ()],
+        output1 = [((), 1), ((), 2), ((), 3)],
+        output2 = [((), 5), ((), 7), ((), 9)]
+      }

--- a/essence-of-live-coding/test/Monad/Trans.hs
+++ b/essence-of-live-coding/test/Monad/Trans.hs
@@ -1,25 +1,28 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
 module Monad.Trans where
 
 -- test-framework
-import Test.Framework
 
 -- test-framework-quickcheck2
-import Test.Framework.Providers.QuickCheck2
 
 -- QuickCheck
-import Test.QuickCheck
 
 -- essence-of-live-coding
 import LiveCoding
-import LiveCoding.Cell.Monad.Trans (State(State))
+import LiveCoding.Cell.Monad.Trans (State (State))
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2
+import Test.QuickCheck
 
-test = testGroup "Monad.Trans"
-  [ testProperty "Migrates into runStateL"
-    $ \(stateT :: Int) (stateInternal :: Int)
-      -> State { .. } === migrate State { stateInternal = 23, .. } stateInternal
-  , testProperty "Migrates from runStateL"
-    $ \(stateT :: Int) (stateInternal :: Int)
-      -> stateInternal === migrate 42 State { .. }
-  ]
+test =
+  testGroup
+    "Monad.Trans"
+    [ testProperty "Migrates into runStateL" $
+        \(stateT :: Int) (stateInternal :: Int) ->
+          State {..} === migrate State {stateInternal = 23, ..} stateInternal,
+      testProperty "Migrates from runStateL" $
+        \(stateT :: Int) (stateInternal :: Int) ->
+          stateInternal === migrate 42 State {..}
+    ]

--- a/essence-of-live-coding/test/RuntimeIO/Launch.hs
+++ b/essence-of-live-coding/test/RuntimeIO/Launch.hs
@@ -1,23 +1,25 @@
 module RuntimeIO.Launch where
 
 -- base
-import Data.IORef
 
 -- hunit
-import Test.HUnit
 
 -- test-framework-hunit
-import Test.Framework.Providers.HUnit
 
 -- essence-of-live-coding
-import LiveCoding
+
 import Control.Concurrent (threadDelay)
+import Data.IORef
+import LiveCoding
+import Test.Framework.Providers.HUnit
+import Test.HUnit
 
 loggingHandle :: IORef [String] -> Handle IO ()
-loggingHandle ref = Handle
-  { create = modifyIORef ref ("Created handle" :)
-  , destroy = const $ modifyIORef ref ("Destroyed handle" :)
-  }
+loggingHandle ref =
+  Handle
+    { create = modifyIORef ref ("Created handle" :),
+      destroy = const $ modifyIORef ref ("Destroyed handle" :)
+    }
 
 testProgram :: IORef [String] -> LiveProgram (HandlingStateT IO)
 testProgram ref = liveCell $ handling $ loggingHandle ref

--- a/essence-of-live-coding/test/TestData/Foo1.hs
+++ b/essence-of-live-coding/test/TestData/Foo1.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+
 module TestData.Foo1 where
 
 -- base
@@ -9,29 +10,31 @@ data Foo = Foo Integer Bool
   deriving (Show, Eq, Typeable, Data)
 
 foo = Foo 1 False
+
 foo' = Foo 2 False
 
 data Bar
   = Bar
-  { barA :: Integer
-  , barD :: Integer
-  , barC :: Bool
-  }
+      { barA :: Integer,
+        barD :: Integer,
+        barC :: Bool
+      }
   | Baar
-  { baarB :: Bool
-  , baarA :: Int
-  }
+      { baarB :: Bool,
+        baarA :: Int
+      }
   deriving (Show, Eq, Typeable, Data)
 
-bar = Bar
-  { barA = 23
-  , barD = 5
-  , barC = True
-  }
+bar =
+  Bar
+    { barA = 23,
+      barD = 5,
+      barC = True
+    }
 
 data Baz = Baz
-  { bazFoo :: Foo
-  , bazBar :: Bar
+  { bazFoo :: Foo,
+    bazBar :: Bar
   }
   deriving (Show, Eq, Typeable, Data)
 

--- a/essence-of-live-coding/test/TestData/Foo2.hs
+++ b/essence-of-live-coding/test/TestData/Foo2.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+
 module TestData.Foo2 where
 
 -- base
@@ -7,46 +8,51 @@ import Data.Typeable
 
 data Foo
   = Fooo Integer
-  | Foo  Integer
+  | Foo Integer
   deriving (Show, Eq, Typeable, Data)
 
 foo = Foo 2
+
 foo' = Foo 1
 
 data Bar
   = Bar
-  { barB :: Integer
-  , barA :: Integer
-  , barC :: String
-  }
+      { barB :: Integer,
+        barA :: Integer,
+        barC :: String
+      }
   | Baar
-  { baarA :: Int
-  }
+      { baarA :: Int
+      }
   deriving (Show, Eq, Typeable, Data)
 
-bar = Bar
-  { barB = 42
-  , barA = 100
-  , barC = "Bar"
-  }
+bar =
+  Bar
+    { barB = 42,
+      barA = 100,
+      barC = "Bar"
+    }
 
-bar' = Bar
-  { barB = 42
-  , barA = 23
-  , barC = "Bar"
-  }
+bar' =
+  Bar
+    { barB = 42,
+      barA = 23,
+      barC = "Bar"
+    }
 
 data Baz = Baz
-  { bazBar :: Bar
-  , bazFoo :: Foo
+  { bazBar :: Bar,
+    bazFoo :: Foo
   }
   deriving (Show, Eq, Typeable, Data)
 
 baz = Baz bar foo
+
 baz' = Baz bar' foo'
 
 data Frob = Frob Integer
   deriving (Show, Eq, Typeable, Data)
 
-frob  = Frob 2
+frob = Frob 2
+
 frob' = Frob 1

--- a/essence-of-live-coding/test/Util.hs
+++ b/essence-of-live-coding/test/Util.hs
@@ -1,45 +1,44 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RecordWildCards #-}
+
 module Util where
 
 -- base
 import Data.Functor.Identity
-import System.IO.Unsafe (unsafePerformIO)
-
 -- QuickCheck
-import Test.QuickCheck
 
 -- essence-of-live-coding
 import LiveCoding
+import System.IO.Unsafe (unsafePerformIO)
+import Test.QuickCheck
 
-{- | A quickcheckable unit test for migrations of cells.
-
-You have to specify a cell which will then receive some input,
-is fed each input element in a step, and produces some output.
-Then the cell is migrated to a second cell, which again consumes input and produces output.
-
-The test is passed if the same input produces the same output.
-
-* 'cell1': The cell before the migration
-* 'cell2': The cell after the migration
-* 'input1': All input the cell before the migration receives
-* 'input2': All input the cell after the migration receives
-* 'output1': The expected output before the migration
-* 'output2': The expected output after the migration
--}
+-- | A quickcheckable unit test for migrations of cells.
+--
+-- You have to specify a cell which will then receive some input,
+-- is fed each input element in a step, and produces some output.
+-- Then the cell is migrated to a second cell, which again consumes input and produces output.
+--
+-- The test is passed if the same input produces the same output.
+--
+-- * 'cell1': The cell before the migration
+-- * 'cell2': The cell after the migration
+-- * 'input1': All input the cell before the migration receives
+-- * 'input2': All input the cell after the migration receives
+-- * 'output1': The expected output before the migration
+-- * 'output2': The expected output after the migration
 data CellMigrationSimulation a b = CellMigrationSimulation
-  { cell1 :: Cell Identity a b
-  , cell2 :: Cell Identity a b
-  , input1 :: [a]
-  , input2 :: [a]
-  , output1 :: [b]
-  , output2 :: [b]
+  { cell1 :: Cell Identity a b,
+    cell2 :: Cell Identity a b,
+    input1 :: [a],
+    input2 :: [a],
+    output1 :: [b],
+    output2 :: [b]
   }
 
 instance (Eq b, Show b) => Testable (CellMigrationSimulation a b) where
-  property CellMigrationSimulation { .. }
-    = let Identity (output1', output2') = simulateCellMigration cell1 cell2 input1 input2
-      in output1 === output1' .&&. output2 === output2'
+  property CellMigrationSimulation {..} =
+    let Identity (output1', output2') = simulateCellMigration cell1 cell2 input1 input2
+     in output1 === output1' .&&. output2 === output2'
 
 -- | Step the first cell with the first input,
 --   migrate it to the second cell,
@@ -67,17 +66,19 @@ inIdentityT = id
 -- | Basic unit test for 'Cell's.
 --   Check whether a given 'input' to your 'cell' results in a given 'output'.
 data CellSimulation a b = CellSimulation
-  { cell :: Cell Identity a b
-  , input :: [a]
-  , output :: [b]
+  { cell :: Cell Identity a b,
+    input :: [a],
+    output :: [b]
   }
 
 instance (Eq b, Show b) => Testable (CellSimulation a b) where
-  property CellSimulation { .. } = property CellMigrationSimulation
-    { cell1 = cell
-    , cell2 = cell
-    , input1 = input
-    , input2 = []
-    , output1 = output
-    , output2 = []
-    }
+  property CellSimulation {..} =
+    property
+      CellMigrationSimulation
+        { cell1 = cell,
+          cell2 = cell,
+          input1 = input,
+          input2 = [],
+          output1 = output,
+          output2 = []
+        }

--- a/essence-of-live-coding/test/Util/LiveProgramMigration.hs
+++ b/essence-of-live-coding/test/Util/LiveProgramMigration.hs
@@ -1,24 +1,25 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Util.LiveProgramMigration where
 
 -- transformers
-import Control.Monad.Trans.RWS.Strict (runRWS, RWS)
-
+import Control.Monad.Trans.RWS.Strict (RWS, runRWS)
 -- QuickCheck
-import Test.QuickCheck
 
 -- essence-of-live-coding
 import LiveCoding
+import Test.QuickCheck
 
-data LiveProgramMigration a b = forall s . LiveProgramMigration
-  { liveProgram1 :: LiveProgram (RWS a b s)
-  , liveProgram2 :: LiveProgram (RWS a b s)
-  , initialState :: s
-  , input1 :: [a]
-  , input2 :: [a]
-  , output1 :: [b]
-  , output2 :: [b]
+data LiveProgramMigration a b = forall s.
+  LiveProgramMigration
+  { liveProgram1 :: LiveProgram (RWS a b s),
+    liveProgram2 :: LiveProgram (RWS a b s),
+    initialState :: s,
+    input1 :: [a],
+    input2 :: [a],
+    output1 :: [b],
+    output2 :: [b]
   }
 
 stepLiveProgramRWS :: Monoid b => LiveProgram (RWS a b s) -> a -> s -> (LiveProgram (RWS a b s), s, b)
@@ -28,14 +29,14 @@ stepsLiveProgramRWS :: Monoid b => LiveProgram (RWS a b s) -> s -> [a] -> (LiveP
 stepsLiveProgramRWS liveProg s [] = (liveProg, s, [])
 stepsLiveProgramRWS liveProg s (a : as) =
   let (liveProg', s', b) = stepLiveProgramRWS liveProg a s
-  in (liveProg', s', b : third (stepsLiveProgramRWS liveProg' s' as))
+   in (liveProg', s', b : third (stepsLiveProgramRWS liveProg' s' as))
 
 third :: (a, b, c) -> c
 third (a, b, c) = c
 
 instance (Monoid b, Eq b, Show b) => Testable (LiveProgramMigration a b) where
-  property LiveProgramMigration { .. } =
+  property LiveProgramMigration {..} =
     let (liveProg', s', output1') = stepsLiveProgramRWS liveProgram1 initialState input1
         liveProg2 = hotCodeSwap liveProgram2 liveProg'
         (_, _, output2') = stepsLiveProgramRWS liveProg2 s' input2
-    in output1 === output1' .&&. output2 === output2'
+     in output1 === output1' .&&. output2 === output2'

--- a/gears/Setup.hs
+++ b/gears/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/gears/app/Gears.hs
+++ b/gears/app/Gears.hs
@@ -4,13 +4,10 @@
 import Control.Arrow
 import Control.Monad (void)
 import Control.Monad.IO.Class
-
 -- essence-of-live-coding
 import LiveCoding
-
 -- essence-of-live-coding-gloss
 import LiveCoding.Gloss
-
 -- essence-of-live-coding-pulse
 import LiveCoding.Pulse
 
@@ -20,44 +17,50 @@ glossCell = withDebuggerC glossCell' statePlay
 glossCell' :: Cell PictureM () Float
 glossCell' = proc () -> do
   gearAngle <- integrate -< 30
-  addPicture             -< gear gearAngle
-  phase     <- integrate -< 5
-  addPicture             -< rotate gearAngle $ blinker phase
-  returnA                -< gearAngle
+  addPicture -< gear gearAngle
+  phase <- integrate -< 5
+  addPicture -< rotate gearAngle $ blinker phase
+  returnA -< gearAngle
 
 blinker :: Float -> Picture
-blinker phase
-  = translate 0 100
-  $ color (greyN $ 0.7 + 0.2 * (sin phase))
-  $ thickCircle 5 10
+blinker phase =
+  translate 0 100 $
+    color (greyN $ 0.7 + 0.2 * (sin phase)) $
+      thickCircle 5 10
 
 gear :: Float -> Picture
-gear angle = scale 3 3 $ rotate angle $ pictures
-  [ color (dim green) $ pictures $
-    thickCircle 20 30
-    : [rotate blockAngle block | blockAngle <- [0, 45 .. 315]]
-  , color red $ pictures [ wedge, scale (-1) 1 wedge ]
-  ]
+gear angle =
+  scale 3 3 $
+    rotate angle $
+      pictures
+        [ color (dim green) $
+            pictures $
+              thickCircle 20 30 :
+                [rotate blockAngle block | blockAngle <- [0, 45 .. 315]],
+          color red $ pictures [wedge, scale (-1) 1 wedge]
+        ]
   where
     block = rectangleSolid 85 15
-    wedge = polygon
-      [ ( 0,  -5)
-      , ( 0,  20)
-      , (10, -10)
-      ]
+    wedge =
+      polygon
+        [ (0, -5),
+          (0, 20),
+          (10, -10)
+        ]
 
 tones = [D, F, A]
 
 pulseCell :: PulseCell IO Float ()
 pulseCell = proc angle -> do
   pulse <- sawtooth -< cycleTones $ round angle
-  addSample         -< pulse
+  addSample -< pulse
 
 cycleTones :: Int -> Float
-cycleTones angle = f
-  $ (tones !!)
-  $ (`mod` length tones)
-  $ angle `div` (60 `div` length tones)
+cycleTones angle =
+  f $
+    (tones !!) $
+      (`mod` length tones) $
+        angle `div` (60 `div` length tones)
 
 liveProgram :: LiveProgram (HandlingStateT IO)
 liveProgram = liveCell mainCell
@@ -65,9 +68,9 @@ liveProgram = liveCell mainCell
 mainCell :: Cell (HandlingStateT IO) () ()
 mainCell = proc () -> do
   angleMaybe <- glossWrapC defaultSettings glossCell -< ()
-  angle <- hold 0                                    -< angleMaybe
-  pulseWrapC 800 pulseCell                           -< angle
-  returnA                                            -< ()
+  angle <- hold 0 -< angleMaybe
+  pulseWrapC 800 pulseCell -< angle
+  returnA -< ()
 
 main :: IO ()
 main = liveMain liveProgram


### PR DESCRIPTION
This PR is not for merging, just for discussion.

I've applied ormolu v0.4.0.0 to the source code here. @turion have a look at the code and see if you like it.

For the import sections I think we should disable ormolu so that it doesn't reorder imports alphabetically. This can be done with 

```
{- ORMOLU_DISABLE -}

imports here

{- ORMOLU_ENABLE -}
```
Then each group of imports can be manually formatted in vs-code by selecting and doing "format selection". haskell-language-server plugin for vscode supports ormolu.

There's a github action available, so it's very easy to check formatting on push:

```
on: [push, pull_request]
name: build
jobs:
  formatting:
    name: Formatting with ormolu
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - uses: mrkkrp/ormolu-action@v5
  build:
    depends-on: formatting
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
        ghc: ['8.8.4','8.10.7']
...
```

Applying ormolu to all files can be done with this script:

```Bash
#!/usr/bin/env bash

check_command() {
    if ! command -v "$1" &> /dev/null
    then
        echo "$1 could not be found"
        exit
    fi
}

check_command git
check_command ormolu
check_command xargs

git ls-files -z '*.hs' | xargs -0 ormolu --mode inplace
```
