### PR TITLE
essence-of-live-coding-warp: build test suite with -threaded

### DIFF
--- a/essence-of-live-coding-warp/essence-of-live-coding-warp.cabal
+++ b/essence-of-live-coding-warp/essence-of-live-coding-warp.cabal
@@ -53,6 +53,9 @@ test-suite test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: test
+  -- The test starts a WARP server, which needs the threaded runtime
+  -- (otherwise: "the TimerManager requires linking against the threaded runtime").
+  ghc-options: -threaded
   build-depends:
       base >= 4.13 && < 4.22
     , http-client >= 0.6.4.1


### PR DESCRIPTION
The `essence-of-live-coding-warp` test suite starts a WARP server, which requires the threaded runtime. Without `-threaded` it fails at runtime:

```
GHC.Internal.Event.Thread.getSystemTimerManager: the TimerManager requires linking against the threaded runtime
test: Uncaught exception ... HttpExceptionRequest ... NoResponseDataReceived
```

This shows up when building on nixpkgs `haskell-updates` ([NixOS/nixpkgs#521260](https://github.com/NixOS/nixpkgs/pull/521260)); the hermetic sandbox reliably hits the timer-manager path. Adds `ghc-options: -threaded` to the test suite (matching the pattern used by e.g. the `monad-schedule` test suite).